### PR TITLE
name k2 container based on deployment.cluster

### DIFF
--- a/cmd/container_helpers.go
+++ b/cmd/container_helpers.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/namesgenerator"
 	"golang.org/x/net/context"
 	"io"
 	"io/ioutil"
@@ -279,7 +278,8 @@ func containerAction(cli *client.Client, ctx context.Context, command []string, 
 		Tty:          true,
 	}
 
-	resp, err := cli.ContainerCreate(ctx, containerConfig, hostConfig, nil, "k2-"+namesgenerator.GetRandomName(1))
+	clusterName := clusterConfig.GetString("deployment.cluster")
+	resp, err := cli.ContainerCreate(ctx, containerConfig, hostConfig, nil, "k2-"+clusterName)
 	if err != nil {
 		fmt.Println(err)
 		panic(err)


### PR DESCRIPTION
at present since container names are randomly generated, and k2cli times out, it's possible for me to have two containers running a `cluster up` and a `cluster down` simultaneously; this should make those cases collide

also this makes it easier to script / grep for which container's logs to follow