### PR TITLE
Terminate options list

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To see all nodes in your kuberentes cluster
 
 To see all installed application accross all namespaces
 ```
-./k2cli tool kubectl --config ~/k2configs/config.yaml get pods --all-namespaces
+./k2cli tool kubectl --config ~/k2configs/config.yaml -- get pods --all-namespaces
 ```
 
 #### Example usage - k2cli tool helm


### PR DESCRIPTION
Following the instructions produces an error:

    ./k2cli tool kubectl --config ~/k2configs/config.yaml get pods --all-namespaces
    Error: unknown flag: --all-namespaces

Terminate the options list to k2cli with the double dash (--) to avoid
parsing the options meant for kubectl.