### PR TITLE
Correct documentation regarding aws configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ variable that K2 will use.
 *  **AWS access secret**  This is your AWS access secret that is paired to the above access key. This field is named
 `deployment.providerConfig.authentication.accessSecret`. This can be either set to the literal value, or to an environment
 variable that K2 will use.
-*  **Note**  The `deployment.providerConfig.authentication.credentialsFile` field is present but is not yet fully implemented.
-For more information see:  https://github.com/samsung-cnct/k2/issues/128
+*  **AWS credentials file**  This is your AWS credentials file that is paired to the below profile. The field is named 
+`deployment.providerConfig.authentication.credentialsFile`. This file and path must exist bind mounted to /root
+inside the container, ie. ${HOME}/.aws/credentials.
+*  **AWS credentials profile** This is the AWS credentials profile name used to select the credentials set from the credentials
+file above.
 
 When the required fields are set your configuration file is ready to go! The default file will create a production-ready
 cluster with the following configuration:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ variable that K2 will use.
 *  **AWS access secret**  This is your AWS access secret that is paired to the above access key. This field is named
 `deployment.providerConfig.authentication.accessSecret`. This can be either set to the literal value, or to an environment
 variable that K2 will use.
-*  **AWS credentials file**  This is your AWS credentials file that is paired to the below profile. The field is named 
+*  **AWS credentials file**  This is your AWS credentials file that is paired to the below profile. The field is named
 `deployment.providerConfig.authentication.credentialsFile`. This file and path must exist bind mounted to /root
 inside the container, ie. ${HOME}/.aws/credentials.
 *  **AWS credentials profile** This is the AWS credentials profile name used to select the credentials set from the credentials
@@ -40,11 +40,11 @@ When the required fields are set your configuration file is ready to go! The def
 cluster with the following configuration:
 
 Role | # | Type
---- | ---  | ---  
-Primary etcd cluster | 5 | t2.small  
-Events etcd cluster | 5 | t2.small  
-Master nodes | 3 | m3.medium  
-Cluster nodes | 3 | c4.large  
+--- | ---  | ---
+Primary etcd cluster | 5 | t2.small
+Events etcd cluster | 5 | t2.small
+Master nodes | 3 | m3.medium
+Cluster nodes | 3 | c4.large
 Special nodes | 2 | m3.medium
 
 We have chosen this configuration based on our own, and other's, publicly available research. It creates an underpowered cluster
@@ -58,7 +58,7 @@ To create your first cluster, run the following command. (This assumes you have 
 ```
 This will take anywhere from five to twenty minutes depending on how AWS is feeling when you execute this command. When
 complete the cluster will exist in its own VPC and will be accesible via the `tool` subcommands. The output artifacts
-will be stored in the default location: `${HOME}/.kraken/<cluster name>`.  
+will be stored in the default location: `${HOME}/.kraken/<cluster name>`.
 
 ### Working with your cluster (using k2cli)
 k2cli uses the K2 image (github.com/samsung_cnct/k2) for all of its operations. The K2 image ships with `kubectl` and `helm`

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The latest official build can be found here: https://github.com/samsung-cnct/k2c
 K2 uses a yaml configuration file for all aspects of the both the Kubernetes cluster and the infrastructure that is
 running it. To build a generic AWS configuration file that has a large number of sensible defaults, you can run:
 ```
-./k2cli generate ~/k2configs/
+./k2cli generate ${HOME}/k2configs/
 ```
-which will create a file at `~/k2configs/config.yaml`. There are three fields that need to be set before this file can
+which will create a file at `${HOME}/k2configs/config.yaml`. There are three fields that need to be set before this file can
 be used:
 *  **Cluster name**  All K2 clusters should have a unique name so their assets can be easily identified by humans in the
 AWS console (no more than 13 characters). The cluster name is set in the `deployment.cluster` field.  This dotted notation refers to the hierarchical
@@ -51,11 +51,11 @@ production quality.
 ### Creating your first cluster
 To create your first cluster, run the following command. (This assumes you have a configuration built as described above.)
 ```
-./k2cli cluster up ~/k2configs/config.yaml
+./k2cli cluster up ${HOME}/k2configs/config.yaml
 ```
 This will take anywhere from five to twenty minutes depending on how AWS is feeling when you execute this command. When
 complete the cluster will exist in its own VPC and will be accesible via the `tool` subcommands. The output artifacts
-will be stored in the default location: `~/.kraken/<cluster name>`.  
+will be stored in the default location: `${HOME}/.kraken/<cluster name>`.  
 
 ### Working with your cluster (using k2cli)
 k2cli uses the K2 image (github.com/samsung_cnct/k2) for all of its operations. The K2 image ships with `kubectl` and `helm`
@@ -71,38 +71,38 @@ to Kubernetes. See the linked documentation for more details.
 #### Example usage - k2cli tool kubectl
 To see all nodes in your Kubernetes cluster
 ```
-./k2cli tool kubectl --config ~/k2configs/config.yaml get nodes
+./k2cli tool kubectl --config ${HOME}/k2configs/config.yaml get nodes
 ```
 
 To see all installed application across all namespaces
 ```
-./k2cli tool kubectl --config ~/k2configs/config.yaml -- get pods --all-namespaces
+./k2cli tool kubectl --config ${HOME}/k2configs/config.yaml -- get pods --all-namespaces
 ```
 
 #### Example usage - k2cli tool helm
 To list all installed charts
 ```
-./k2cli tool helm --config ~/k2configs/config.yaml list
+./k2cli tool helm --config ${HOME}/k2configs/config.yaml list
 ```
 
 To install the Kafka chart maintained by Samsung CNCT.
 ```
-./k2cli tool helm --config ~/k2configs/config.yaml install atlas/kafka
+./k2cli tool helm --config ${HOME}/k2configs/config.yaml install atlas/kafka
 ```
 
 ### Working with your cluster (using host installed tools)
 The file that is required for both helm and kubectl to connect to, and interact with, your Kubernetes deployment is saved to your
-local machine in the output directory. By default, this directory is `~/.kraken/<cluster name>/`. The filename is `admin.kubeconfig`.
+local machine in the output directory. By default, this directory is `${HOME}/.kraken/<cluster name>/`. The filename is `admin.kubeconfig`.
 
 #### Example usage - local kubectl
 To list all nodes in your Kubernetes cluster
 ```
-kubectl --kubeconfig=~/.kraken/<cluster name>/admin.kubeconfig --cluster=<cluster name> get nodes
+kubectl --kubeconfig=${HOME}/.kraken/<cluster name>/admin.kubeconfig --cluster=<cluster name> get nodes
 ```
 
 To list all installed applications across all namespaces
 ```
-kubectl --kubeconfig=~/.kraken/<cluster name>/admin.kubeconfig --cluster=<cluster name> get pods --all-namespaces
+kubectl --kubeconfig=${HOME}/.kraken/<cluster name>/admin.kubeconfig --cluster=<cluster name> get pods --all-namespaces
 ```
 
 #### Example usage - local helm
@@ -111,19 +111,19 @@ directory
 
 To list all installed charts
 ```
-KUBECONFIG=~/.kraken/<cluster name>/admin.kubeconfig HELM_HOME=~/.kraken/<cluster name>/.helm helm list
+KUBECONFIG=${HOME}/.kraken/<cluster name>/admin.kubeconfig HELM_HOME=${HOME}/.kraken/<cluster name>/.helm helm list
 ```
 
 To install the Kafka chart maintained by Samsung CNCT.
 ```
-KUBECONFIG=~/.kraken/<cluster name>/admin.kubeconfig HELM_HOME=~/.kraken/<cluster name>/.helm helm install atlas/kafka
+KUBECONFIG=${HOME}/.kraken/<cluster name>/admin.kubeconfig HELM_HOME=${HOME}/.kraken/<cluster name>/.helm helm install atlas/kafka
 ```
 
 ### Destroying the running cluster
 While not something to be done in production, during development when you are done with your cluster (or with a quickstart) it's
 best to clean up your resources. To destroy the running cluster from this guide, simply run:
 ```
-./k2cli cluster down ~/k2configs/config.yaml
+./k2cli cluster down ${HOME}/k2configs/config.yaml
 ```
 
 **Note:** if you have specified an '--output' directory during the creation command, make sure you specify it here or the cluster


### PR DESCRIPTION
The AWS configuration file does function correctly when referenced as it
would be inside the docker bind mount. Documented as such.

Fixes #38