### PR TITLE
Cluster name hack

### DIFF
--- a/cmd/container_helpers.go
+++ b/cmd/container_helpers.go
@@ -438,5 +438,7 @@ func writeLog(logFilePath string, out []byte) {
 }
 
 func getContainerName() string {
-	return os.ExpandEnv(clusterConfig.GetString("deployment.clusters[0].name"))
+	// only supports first cluster name right now
+	firstCluster := clusterConfig.Get("deployment.clusters").([]interface{})[0].(map[interface{}] interface{})
+	return os.ExpandEnv(firstCluster["name"].(string))
 }

--- a/cmd/container_helpers.go
+++ b/cmd/container_helpers.go
@@ -438,5 +438,5 @@ func writeLog(logFilePath string, out []byte) {
 }
 
 func getContainerName() string {
-	return os.ExpandEnv(clusterConfig.GetString("deployment.cluster"))
+	return os.ExpandEnv(clusterConfig.GetString("deployment.clusters[0].name"))
 }


### PR DESCRIPTION
this only supports one cluster in the config file at a time.  Will create a follow-on ticket for handling multiple clusters.