### PR TITLE
guard against name not exsiting and rev version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME      := k2cli
-VERSION   := 1.0.3
+VERSION   := 1.0.5
 TYPE      := alpha
 COMMIT    := $(shell git rev-parse HEAD)
 godep=GOPATH=$(shell godep path):${GOPATH}

--- a/cmd/container_helpers.go
+++ b/cmd/container_helpers.go
@@ -467,6 +467,11 @@ func writeLog(logFilePath string, out []byte) {
 
 func getContainerName() string {
 	// only supports first cluster name right now
-	firstCluster := clusterConfig.Get("deployment.clusters").([]interface{})[0].(map[interface{}]interface{})
-	return os.ExpandEnv(firstCluster["name"].(string))
+	clusters := clusterConfig.Get("deployment.clusters")
+	if clusters != nil {
+		firstCluster := clusters.([]interface{})[0].(map[interface{}]interface{})
+		return os.ExpandEnv(firstCluster["name"].(string))
+	} else {
+		return "cluster-name-missing"
+	}
 }


### PR DESCRIPTION
there are two scenarios that a cluster won't have a name:
- before a config has been genereted
- after a config has been generated but before a name has been set

we still want to access k2 functionality for these and not have k2cli
blow up.

revving version as this is an important patch and I'll cut a release
when its merged