### PR TITLE
K2cliupdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ be used:
 AWS console (no more than 13 characters). The cluster name is set in the `deployment.clusters.name` field.  This dotted notation refers to the hierarchical
 structure of a yaml file where cluster is a sub field of deployment. This line is towards the bottom of the file in the `deployment` section.
 
-The following fields are in the `definitions` section of the configuration file. 
+The following fields are in the `definitions` section of the configuration file.
 In lieu of specifying all of the following, you may just put your credentials file and K2 will grab the authentication specs from there.
 *  **AWS access key**  Your AWS access key is required for programmatic access to AWS. The field is named
 `providerConfig.authentication.accessKey`. This can be either set to the literal value, or to an environment
@@ -153,6 +153,17 @@ To install the Kafka chart maintained by Samsung CNCT.
 ```
 KUBECONFIG=${HOME}/.kraken/<cluster name>/admin.kubeconfig HELM_HOME=${HOME}/.kraken/<cluster name>/.helm helm install atlas/kafka
 ```
+
+### Updating your cluster
+You may update your nodepools with k2cli. To do so, please make desired changes in your configuration file, and then run k2cli's cluster upgrade command, as described below, pointing to your configuration file.
+
+#### Running K2cli update
+You can specify different versions of Kubernetes in each nodepool. This may affect the compatibility of your cluster's K2-provided services. You can also update nodepool counts and instance types. Specify which nodepools you wish to update with a comma-separated list of the names of the nodepools. Please be patient; this process may take a while; about ten minutes per node.
+
+- Step 1: Make appropriate changes to configuration file
+- Step 2: Run
+```bash
+k2cli cluster update ${HOME}/k2configs/config.yaml <your,nodepools,here>
 
 ### Destroying the running cluster
 While not something to be done in production, during development when you are done with your cluster (or with a quickstart) it's

--- a/README.md
+++ b/README.md
@@ -155,15 +155,16 @@ KUBECONFIG=${HOME}/.kraken/<cluster name>/admin.kubeconfig HELM_HOME=${HOME}/.kr
 ```
 
 ### Updating your cluster
-You may update your nodepools with k2cli. To do so, please make desired changes in your configuration file, and then run k2cli's cluster upgrade command, as described below, pointing to your configuration file.
+You may update your nodepools with k2cli, specifically the Kubernetes version, the nodepool counts and instance types. To do so, please make desired changes in your configuration file, and then run k2cli's cluster update command, as described below, pointing to your configuration file.
 
 #### Running K2cli update
-You can specify different versions of Kubernetes in each nodepool. This may affect the compatibility of your cluster's K2-provided services. You can also update nodepool counts and instance types. Specify which nodepools you wish to update with a comma-separated list of the names of the nodepools. Please be patient; this process may take a while; about ten minutes per node.
+You can specify different versions of Kubernetes in each nodepool. Note: this may affect the compatibility of your cluster's K2-provided services. Specify which nodepools you wish to update with a comma-separated list of the names of the nodepools. Please be patient; this process may take a while; about ten minutes per node.
 
 - Step 1: Make appropriate changes to configuration file
 - Step 2: Run
 ```bash
 k2cli cluster update ${HOME}/k2configs/config.yaml <your,nodepools,here>
+```
 
 ### Destroying the running cluster
 While not something to be done in production, during development when you are done with your cluster (or with a quickstart) it's

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -37,7 +37,7 @@ var updateCmd = &cobra.Command{
 		}
 
 		if len(args) == 1 {
-			return errors.New("You must add a comma-separated list of nodepools to this command, for example: \n k2cli cluster update masterNodes,clusterNodes,otherNodes")
+			return errors.New("You must specify which nodepools you want to update. Please pass a comma-separated list of nodepools to this command, for example: \n k2cli cluster update masterNodes,clusterNodes,otherNodes")
 		}
 
 		_, err := os.Stat(k2ConfigPath)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -17,10 +17,11 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 var updateStagesList string
@@ -53,7 +54,6 @@ var updateCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-
 		terminalSpinner.Prefix = "Pulling image '" + containerImage + "' "
 		terminalSpinner.Start()
 
@@ -73,8 +73,9 @@ var updateCmd = &cobra.Command{
 			"ansible/inventory/localhost",
 			"ansible/update.yaml",
 			"--extra-vars",
-			"config_path=" + k2ConfigPath + " config_base=" + outputLocation + " config_forced=" + strconv.FormatBool(configForced) + " kraken_action=up ",
+			"config_path=" + k2ConfigPath + " config_base=" + outputLocation + " config_forced=" + strconv.FormatBool(configForced) + " kraken_action=update ",
 			"--tags",
+			// "--nodepools",
 			updateStagesList,
 		}
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -18,13 +18,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
 )
-
-var updateStagesList string
 
 // updateCmd represents the update command
 var updateCmd = &cobra.Command{
@@ -49,6 +46,8 @@ var updateCmd = &cobra.Command{
 			panic(err)
 		}
 
+		// if args[1]
+
 		initK2Config(k2ConfigPath)
 
 		return nil
@@ -67,16 +66,15 @@ var updateCmd = &cobra.Command{
 		terminalSpinner.Prefix = "Updating cluster '" + getContainerName() + "' "
 		terminalSpinner.Start()
 
+		nodepools := args[1]
+
 		command := []string{
 			"ansible-playbook",
 			"-i",
 			"ansible/inventory/localhost",
 			"ansible/update.yaml",
 			"--extra-vars",
-			"config_path=" + k2ConfigPath + " config_base=" + outputLocation + " config_forced=" + strconv.FormatBool(configForced) + " kraken_action=update ",
-			"--tags",
-			// "--nodepools",
-			updateStagesList,
+			"config_path=" + k2ConfigPath + " config_base=" + outputLocation + " kraken_action=update " + " update_nodepools=" + nodepools,
 		}
 
 		ctx, cancel := getTimedContext()
@@ -118,10 +116,4 @@ var updateCmd = &cobra.Command{
 
 func init() {
 	clusterCmd.AddCommand(updateCmd)
-	updateCmd.PersistentFlags().StringVarP(
-		&updateStagesList,
-		"stages",
-		"s",
-		"all",
-		"comma-separated list of K2 stages to run. Run 'k2cli help topic stages' for more info.")
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -36,6 +36,10 @@ var updateCmd = &cobra.Command{
 			k2ConfigPath = os.ExpandEnv(args[0])
 		}
 
+		if len(args) == 1 {
+			return errors.New("You must add a comma-separated list of nodepools to this command, for example: \n k2cli cluster update masterNodes,clusterNodes,otherNodes")
+		}
+
 		_, err := os.Stat(k2ConfigPath)
 		if os.IsNotExist(err) {
 			return errors.New("File " + k2ConfigPath + " does not exist!")
@@ -45,8 +49,6 @@ var updateCmd = &cobra.Command{
 			fmt.Println(err)
 			panic(err)
 		}
-
-		// if args[1]
 
 		initK2Config(k2ConfigPath)
 
@@ -77,8 +79,8 @@ var updateCmd = &cobra.Command{
 			"config_path=" + k2ConfigPath + " config_base=" + outputLocation + " kraken_action=update " + " update_nodepools=" + nodepools,
 		}
 
-		ctx, cancel := getTimedContext()
-		defer cancel()
+		ctx := getContext()
+		// defer cancel()
 		resp, statusCode, timeout := containerAction(cli, ctx, command, k2ConfigPath)
 		defer timeout()
 


### PR DESCRIPTION
This PR addresses ticket #70 .

Point of interest: these changes disable k2cli's timeout of 20 minutes for the update command, since updating a node takes quite a long time, around ten minutes per node.

ToReview:

- Verify update command works as expected/necessary with k2
- Make sure the readme makes sense