### PR TITLE
Support TLS on Docker API connections

### DIFF
--- a/cmd/container_helpers.go
+++ b/cmd/container_helpers.go
@@ -329,8 +329,6 @@ func (conf *DockerClientConfig) isInheritedFromEnviron() bool {
 		"key":     []string{conf.TLSKey, conf.GetDefaultTLSKey()},
 	}
 
-	// log.Printf("Evaluating config environ: %v", compare)
-
 	for _, vals := range compare {
 		if vals[0] != vals[1] {
 			return false
@@ -402,8 +400,6 @@ func getClient() *client.Client {
 			"User-Agent": fmt.Sprintf("engine-api-cli-%s", config.DockerAPIVersion),
 		}
 
-		// log.Printf("Configuring Docker client with %#v", config)
-
 		cli, err = client.NewClient(config.DockerHost, config.DockerAPIVersion, httpClient, headers)
 	}
 
@@ -411,8 +407,6 @@ func getClient() *client.Client {
 		fmt.Println(err)
 		panic(err)
 	}
-
-	// log.Printf("Prepared client: %#v", cli)
 
 	return cli
 }

--- a/cmd/container_helpers.go
+++ b/cmd/container_helpers.go
@@ -241,8 +241,11 @@ func parseMounts(deployment reflect.Value, hostConfig *container.HostConfig, con
 }
 
 func getClient() *client.Client {
-	defaultHeaders := map[string]string{"User-Agent": "engine-api-cli-1.0"}
-	cli, err := client.NewClient(dockerHost, "", nil, defaultHeaders)
+
+	// This wraps the previously used client.NewClient(), with support for
+	// configuration via environment variables.
+	cli, err := client.NewEnvClient()
+
 	if err != nil {
 		fmt.Println(err)
 		panic(err)


### PR DESCRIPTION
This adaptation brings `k2cli` up-to-speed with Docker's own command line client, to support API connections with TLS, as well as existing Unix socket and TCP host strings, configured via environment variables.

Previously the `k2cli` supported only unencrypted connections, via the Docker unix socket or a plain TCP socket. (No issue was filed in this regard.) This patch supports a wider array of configurations, all within Docker's own conventions. 

```release-note
Enable support for Docker environment variables (e.g. `DOCKER_HOST`) to configure engine API client. Command line arguments (e.g. `-d {host}`) will override OS environ.
```
