### PR TITLE
use the scripts that exist in K2

### DIFF
--- a/cmd/kubectl.go
+++ b/cmd/kubectl.go
@@ -43,7 +43,7 @@ var kubectlCmd = &cobra.Command{
 		backgroundCtx := getContext()
 		pullImage(cli, backgroundCtx, getAuthConfig64(cli, backgroundCtx))
 
-		command := []string{"kubectl"}
+		command := []string{"./computed_kubectl.sh", k2Config}
 		for _, element := range args {
 			command = append(command, strings.Split(element, " ")...)
 		}


### PR DESCRIPTION
kubectl will always be present for any major.minor version pair
so no footwork is rquired in k2cli.  just use it.

this requires samsung-cnct/k2#614

<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**: makes `k2cli tool kubectl` work all the time

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #67 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
