### PR TITLE
Altered generate subcommand to exit if config file already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ running it. To build a generic AWS configuration file that has a large number of
 ```
 k2cli generate
 ```
-which will create a file at `${HOME}/.kraken/config.yaml`  **Note:** The `generate` subcommand will overwrite this file if it currently exists.  
+which will create a file at `${HOME}/.kraken/config.yaml`  **Note:** If a config file already exists the `generate` subcommand will fail with the message: `A K2 config file already exists at <your config location> - rename, delete or move it to generate a new default K2 config file`
 
 Or you may specify a path with:
 ```

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -15,10 +15,12 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
+
+	"github.com/spf13/cobra"
 )
 
 var generatePath string
@@ -36,9 +38,17 @@ var generateCmd = &cobra.Command{
 
 func preRunEFunc(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
+
 		generatePath = os.ExpandEnv(args[0])
 	} else {
 		generatePath = os.ExpandEnv("$HOME/.kraken/config.yaml")
+	}
+
+	fmt.Printf(generatePath)
+
+	if err := checkConfig(generatePath);  err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
 
 	if provider == "gke" {
@@ -52,6 +62,15 @@ func preRunEFunc(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+func checkConfig(generatePath string) error {
+	if _, err := os.Stat(generatePath); !os.IsNotExist(err) {
+		err := errors.New(fmt.Sprintf("Attempted to create %s, but the file already exists: rename, delete or move it, then run 'generate' subcommand again to generate a new default K2 config file", generatePath))
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
To test: run local binary of k2cli with this generate.go code, run `./k2cli generate` once to generate config file, run again and you should see an error that the config file already exists.

Fixes: https://github.com/samsung-cnct/k2cli/issues/89