### PR TITLE
K2 shell script calls have bin in filepath

### DIFF
--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -93,7 +93,7 @@ func verifyHelmPath(helmPath string, cli *client.Client) string {
 
 // Get the k8s version from k2
 func getK8sVersion(cli *client.Client, backgroundCtx context.Context, args []string) string {
-	command := []string{"kraken/max_k8s_version.sh", k2Config}
+	command := []string{"kraken/bin/max_k8s_version.sh", k2Config}
 	for _, element := range args {
 		command = append(command, strings.Split(element, " ")...)
 	}

--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -93,7 +93,7 @@ func verifyHelmPath(helmPath string, cli *client.Client) string {
 
 // Get the k8s version from k2
 func getK8sVersion(cli *client.Client, backgroundCtx context.Context, args []string) string {
-	command := []string{"kraken/bin/max_k8s_version.sh", k2Config}
+	command := []string{"/kraken/bin/max_k8s_version.sh", k2Config}
 	for _, element := range args {
 		command = append(command, strings.Split(element, " ")...)
 	}

--- a/cmd/kubectl.go
+++ b/cmd/kubectl.go
@@ -43,7 +43,7 @@ var kubectlCmd = &cobra.Command{
 		backgroundCtx := getContext()
 		pullImage(cli, backgroundCtx, getAuthConfig64(cli, backgroundCtx))
 
-		command := []string{"./bin/computed_kubectl.sh", k2Config}
+		command := []string{"/kraken/bin/computed_kubectl.sh", k2Config}
 		for _, element := range args {
 			command = append(command, strings.Split(element, " ")...)
 		}

--- a/cmd/kubectl.go
+++ b/cmd/kubectl.go
@@ -43,7 +43,7 @@ var kubectlCmd = &cobra.Command{
 		backgroundCtx := getContext()
 		pullImage(cli, backgroundCtx, getAuthConfig64(cli, backgroundCtx))
 
-		command := []string{"./computed_kubectl.sh", k2Config}
+		command := []string{"./bin/computed_kubectl.sh", k2Config}
 		for _, element := range args {
 			command = append(command, strings.Split(element, " ")...)
 		}


### PR DESCRIPTION
As per https://github.com/samsung-cnct/k2/issues/525, all k2 shell scripts now live in a bin folder. This is a quick fix to change filepaths to reflect this.

Completes issue #124 

Addresses K2 Issue: https://github.com/samsung-cnct/k2/issues/525 
K2 PR: https://github.com/samsung-cnct/k2/pull/718

ToReview: Check if all file paths reflect the correct location in k2