### PR TITLE
Added ability check helm_override_{cluster.name} env in k2cli

### DIFF
--- a/cmd/container_helpers.go
+++ b/cmd/container_helpers.go
@@ -152,6 +152,7 @@ func clusterHelp(help helptype, clusterConfigFile string) {
 	}
 }
 
+// Convert dashes to underscore (if any) in cluster name and append to helm_override_ to be able to pull correct env for helm override
 func setHelmOverrideEnv(name string) string {
 	clusterName := strings.Replace(name, "-", "_", -1)
 	helmOverrideVar := "helm_override_" + clusterName

--- a/cmd/container_helpers.go
+++ b/cmd/container_helpers.go
@@ -152,24 +152,25 @@ func clusterHelp(help helptype, clusterConfigFile string) {
 	}
 }
 
-func setHelmOverrideEnv() string {
-	clusterName := strings.Replace(getContainerName(), "-", "_", -1)
+func setHelmOverrideEnv(name string) string {
+	clusterName := strings.Replace(name, "-", "_", -1)
 	helmOverrideVar := "helm_override_" + clusterName
 	return helmOverrideVar
 }
 
 func containerEnvironment() []string {
+	containerName := getContainerName()
 	envs := []string{"ANSIBLE_NOCOLOR=True",
 		"DISPLAY_SKIPPED_HOSTS=0",
-		"KUBECONFIG=" + path.Join(outputLocation, getContainerName(), "admin.kubeconfig"),
-		"HELM_HOME=" + path.Join(outputLocation, getContainerName(), ".helm")}
+		"KUBECONFIG=" + path.Join(outputLocation, containerName, "admin.kubeconfig"),
+		"HELM_HOME=" + path.Join(outputLocation, containerName, ".helm")}
 
 	envs = appendIfValueNotEmpty(envs, "AWS_ACCESS_KEY_ID")
 	envs = appendIfValueNotEmpty(envs, "AWS_SECRET_ACCESS_KEY")
 	envs = appendIfValueNotEmpty(envs, "AWS_DEFAULT_REGION")
 	envs = appendIfValueNotEmpty(envs, "CLOUDSDK_COMPUTE_ZONE")
 	envs = appendIfValueNotEmpty(envs, "CLOUDSDK_COMPUTE_REGION")
-	envs = appendIfValueNotEmpty(envs, setHelmOverrideEnv())
+	envs = appendIfValueNotEmpty(envs, setHelmOverrideEnv(containerName))
 
 	return envs
 }

--- a/cmd/container_helpers.go
+++ b/cmd/container_helpers.go
@@ -152,6 +152,12 @@ func clusterHelp(help helptype, clusterConfigFile string) {
 	}
 }
 
+func setHelmOverrideEnv() string {
+	clusterName := strings.Replace(getContainerName(), "-", "_", -1)
+	helmOverrideVar := "helm_override_" + clusterName
+	return helmOverrideVar
+}
+
 func containerEnvironment() []string {
 	envs := []string{"ANSIBLE_NOCOLOR=True",
 		"DISPLAY_SKIPPED_HOSTS=0",
@@ -163,6 +169,7 @@ func containerEnvironment() []string {
 	envs = appendIfValueNotEmpty(envs, "AWS_DEFAULT_REGION")
 	envs = appendIfValueNotEmpty(envs, "CLOUDSDK_COMPUTE_ZONE")
 	envs = appendIfValueNotEmpty(envs, "CLOUDSDK_COMPUTE_REGION")
+	envs = appendIfValueNotEmpty(envs, setHelmOverrideEnv())
 
 	return envs
 }

--- a/cmd/container_helpers_test.go
+++ b/cmd/container_helpers_test.go
@@ -48,3 +48,12 @@ func TestAddEnvironmentVarIfNotEmpty(t *testing.T) {
 		t.Error("For", envs, "expected to find key", goodEnvVar, "but not found.")
 	}
 }
+
+func TestHelmOverrideEnv(t *testing.T) {
+	nameOne := "test-123"
+
+	correctName := setHelmOverrideEnv(nameOne)
+	if correctName != "helm_override_test_123" {
+		t.Errorf("name coversion failed, got: %s, want: %s.", correctName, "helm_override_test_123")
+	}
+}


### PR DESCRIPTION
This fix allows the user to run `export helm_override_cluster_name=true/false` when the current version of helm does not support the running version of k8s.

Fixes https://github.com/samsung-cnct/k2cli/issues/120
