### PR TITLE
K2cli migration to Kraken

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,11 +4,11 @@
 
 | Component | Repo                                                                           |
 | --------- | ------------------------------------------------------------------------------ |
-| k2        | [samsung-cnct/k2cli](https://github.com/samsung-cnct/k2cli/issues/new)         |
-| k2-charts | [samsung-cnct/k2-charts](https://github.com/samsung-cnct/k2-charts/issues/new) |
-| k2-tools  | [samsung-cnct/k2-tools](https://github.com/samsung-cnct/k2-tools/issues/new)   |
+| Krakenlib     | [samsung-cnct/k2](https://github.com/samsung-cnct/k2/issues/new)         |
+| Kraken-charts | [samsung-cnct/k2-charts](https://github.com/samsung-cnct/k2-charts/issues/new) |
+| Kraken-tools  | [samsung-cnct/k2-tools](https://github.com/samsung-cnct/k2-tools/issues/new)   |
 
-**What keywords did you search in k2cli issues before filing this one?** (If you have found any duplicates, you should instead reply there.):
+**What keywords did you search in Kraken issues before filing this one?** (If you have found any duplicates, you should instead reply there.):
 
 ---
 
@@ -28,7 +28,7 @@ might close your issue.  If we're wrong, PLEASE feel free to reopen it and
 explain why.
 -->
 
-**k2cli version** (use `k2cli version`):
+**Kraken version** (use `kraken version`):
 
 
 **Environment**:
@@ -36,7 +36,7 @@ explain why.
 Please be sure not to submit any confidential information (e.g. ssh keys, provider secrets, etc.) as issues are publicly accessible.
 
 - **Environment variables** (e.g. `env | grep 'KRAKEN_`):
-- **Configuration files (`~/.kraken/config.yaml` or the file passed to `k2cli --config`) **:
+- **Configuration files (`~/.kraken/config.yaml` or the file passed to `kraken --config`) **:
 - **Others**:
 
 
@@ -50,4 +50,3 @@ Please be sure not to submit any confidential information (e.g. ssh keys, provid
 
 
 **Anything else we need to know**:
-

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,15 @@ godep=GOPATH=$(shell godep path):${GOPATH}
 build:
 	@godep go build -ldflags "-X github.com/samsung-cnct/k2cli/cmd.KrakenMajorMinorPatch=$(VERSION) \
 		-X github.com/samsung-cnct/k2cli/cmd.KrakenType=$(TYPE) \
-		-X github.com/samsung-cnct/k2cli/cmd.KrakenGitCommit=$(COMMIT)"
+		-X github.com/samsung-cnct/k2cli/cmd.KrakenGitCommit=$(COMMIT) \
+		-X github.com/samsung-cnct/k2cli/cmd.krakenlibTag=$(KLIB_VER)"
 
 compile:
 	@rm -rf build/
 	@$(GODEP) gox -ldflags "-X github.com/samsung-cnct/k2cli/cmd.KrakenMajorMinorPatch=$(VERSION) \
 									-X github.com/samsung-cnct/k2cli/cmd.KrakenType=$(TYPE) \
-									-X github.com/samsung-cnct/k2cli/cmd.KrakenGitCommit=$(COMMIT)" \
+									-X github.com/samsung-cnct/k2cli/cmd.KrakenGitCommit=$(COMMIT) \
+									-X github.com/samsung-cnct/k2cli/cmd.krakenlibTag=$(KLIB_VER)"
 	-osarch="linux/386" \
 	-osarch="linux/amd64" \
 	-osarch="darwin/amd64" \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NAME      := k2cli
+NAME      := Kraken
 VERSION   := 1.0.8
 KLIB_VER  := latest
 TYPE      := stable
@@ -8,17 +8,15 @@ godep=GOPATH=$(shell godep path):${GOPATH}
 
 
 build:
-	@godep go build -ldflags "-X github.com/samsung-cnct/k2cli/cmd.K2CliMajorMinorPatch=$(VERSION) \
-		-X github.com/samsung-cnct/k2cli/cmd.K2CliType=$(TYPE) \
-		-X github.com/samsung-cnct/k2cli/cmd.K2CliGitCommit=$(COMMIT) \
-		-X github.com/samsung-cnct/k2cli/cmd.k2Tag=$(KLIB_VER)"
+	@godep go build -ldflags "-X github.com/samsung-cnct/k2cli/cmd.KrakenMajorMinorPatch=$(VERSION) \
+		-X github.com/samsung-cnct/k2cli/cmd.KrakenType=$(TYPE) \
+		-X github.com/samsung-cnct/k2cli/cmd.KrakenGitCommit=$(COMMIT)"
 
 compile:
 	@rm -rf build/
-	@$(GODEP) gox -ldflags "-X github.com/samsung-cnct/k2cli/cmd.K2CliMajorMinorPatch=$(VERSION) \
-									-X github.com/samsung-cnct/k2cli/cmd.K2CliType=$(TYPE) \
-									-X github.com/samsung-cnct/k2cli/cmd.K2CliGitCommit=$(COMMIT) \
-									-X github.com/samsung-cnct/k2cli/cmd.k2Tag=$(KLIB_VER)" \
+	@$(GODEP) gox -ldflags "-X github.com/samsung-cnct/k2cli/cmd.KrakenMajorMinorPatch=$(VERSION) \
+									-X github.com/samsung-cnct/k2cli/cmd.KrakenType=$(TYPE) \
+									-X github.com/samsung-cnct/k2cli/cmd.KrakenGitCommit=$(COMMIT)" \
 	-osarch="linux/386" \
 	-osarch="linux/amd64" \
 	-osarch="darwin/amd64" \
@@ -26,9 +24,9 @@ compile:
 	./...
 
 install:
-	@godep go install -ldflags "-X github.com/samsung-cnct/k2cli/cmd.K2CliMajorMinorPatch=$(VERSION) \
-									-X github.com/samsung-cnct/k2cli/cmd.K2CliType=$(TYPE) \
-									-X github.com/samsung-cnct/k2cli/cmd.K2CliGitCommit=$(COMMIT)"
+	@godep go install -ldflags "-X github.com/samsung-cnct/k2cli/cmd.KrakenMajorMinorPatch=$(VERSION) \
+									-X github.com/samsung-cnct/k2cli/cmd.KrakenType=$(TYPE) \
+									-X github.com/samsung-cnct/k2cli/cmd.KrakenGitCommit=$(COMMIT)"
 
 deps:
 	go get github.com/mitchellh/gox

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,14 @@ build:
 	@godep go build -ldflags "-X github.com/samsung-cnct/k2cli/cmd.KrakenMajorMinorPatch=$(VERSION) \
 		-X github.com/samsung-cnct/k2cli/cmd.KrakenType=$(TYPE) \
 		-X github.com/samsung-cnct/k2cli/cmd.KrakenGitCommit=$(COMMIT) \
-		-X github.com/samsung-cnct/k2cli/cmd.krakenlibTag=$(KLIB_VER)"
+		-X github.com/samsung-cnct/k2cli/cmd.KrakenlibTag=$(KLIB_VER)"
 
 compile:
 	@rm -rf build/
 	@$(GODEP) gox -ldflags "-X github.com/samsung-cnct/k2cli/cmd.KrakenMajorMinorPatch=$(VERSION) \
 									-X github.com/samsung-cnct/k2cli/cmd.KrakenType=$(TYPE) \
 									-X github.com/samsung-cnct/k2cli/cmd.KrakenGitCommit=$(COMMIT) \
-									-X github.com/samsung-cnct/k2cli/cmd.krakenlibTag=$(KLIB_VER)"
+									-X github.com/samsung-cnct/k2cli/cmd.KrakenlibTag=$(KLIB_VER)"
 	-osarch="linux/386" \
 	-osarch="linux/amd64" \
 	-osarch="darwin/amd64" \

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 Kraken is a command-line interface for [Krakenlib](https://github.com/samsung-cnct/k2).
 
 ## Getting Started
-This Getting Started guide describes a Kubernetes deployment to AWS. Krakenlib currently also supports deployments to GKE, but not
-by default.
+This Getting Started guide describes a Kubernetes deployment to AWS. Kraken currently also supports deployments to GKE, but not by default.
 
 ### Requirements
 Docker must be installed on the machine where you run Kraken, and your user must have permissions to run it.
@@ -24,7 +23,7 @@ running it. To build a generic AWS configuration file that has a large number of
 ```
 kraken generate
 ```
-which will create a file at `${HOME}/.kraken/config.yaml`  **Note:** If a config file already exists the `generate` subcommand will fail with the message: `A Krakenlib config file already exists at <your config location> - rename, delete or move it to generate a new default Krakenlib config file`
+which will create a file at `${HOME}/.kraken/config.yaml`  **Note:** If a config file already exists the `generate` subcommand will fail with the message: `A Kraken config file already exists at <your config location> - rename, delete or move it to generate a new default Kraken config file`
 
 Or you may specify a path with:
 ```
@@ -39,17 +38,17 @@ kraken generate --provider gke
 
 #### Required Configuration Changes
 For an AWS cluster there are several fields that need to be set before this file can be used:
-*  **Cluster name**  All Krakenlib clusters should have a unique name so their assets can be easily identified by humans in the
+*  **Cluster name**  All Kraken clusters should have a unique name so their assets can be easily identified by humans in the
 AWS console (no more than 13 characters). The cluster name is set in the `deployment.clusters.name` field.  This dotted notation refers to the hierarchical structure of a yaml file where cluster is a sub field of deployment. This line is towards the bottom of the file in the `deployment` section.
 
 The following fields are in the `definitions` section of the configuration file.
-In lieu of specifying all of the following, you may just put your credentials file and Krakenlib will grab the authentication specs from there.
+In lieu of specifying all of the following, you may just put your credentials file and Kraken will grab the authentication specs from there.
 *  **AWS access key**  Your AWS access key is required for programmatic access to AWS. The field is named
 `providerConfigs.authentication.accessKey`. This can be either set to the literal value, or to an environment
-variable that Krakenlib will use.
+variable that Kraken will use.
 *  **AWS access secret**  This is your AWS access secret that is paired to the above access key. This field is named
 `providerConfigs.authentication.accessSecret`. This can be either set to the literal value, or to an environment
-variable that Krakenlib will use.
+variable that Kraken will use.
 *  **AWS credentials file**  This is your AWS credentials file that is paired to the below profile. The field is named
 `providerConfigs.authentication.credentialsFile`. This file and path must exist bind mounted to /root
 inside the container, ie. ${HOME}/.aws/credentials.
@@ -200,7 +199,7 @@ KUBECONFIG=${HOME}/.kraken/<cluster name>/admin.kubeconfig HELM_HOME=${HOME}/.kr
 You may update your nodepools with Kraken, specifically the Kubernetes version, the nodepool counts and instance types. To do so, please make desired changes in your configuration file, and then run Kraken's cluster update command, as described below, pointing to your configuration file.
 
 #### Running Kraken update
-You can specify different versions of Kubernetes in each nodepool. Note: this may affect the compatibility of your cluster's Krakenlib-provided services. Specify which nodepools you wish to update with a comma-separated list of the names of the nodepools. Please be patient; this process may take a while; about ten minutes per node.
+You can specify different versions of Kubernetes in each nodepool. Note: this may affect the compatibility of your cluster's Kraken-provided services. Specify which nodepools you wish to update with a comma-separated list of the names of the nodepools. Please be patient; this process may take a while; about ten minutes per node.
 
 - Step 1: Make appropriate changes to configuration file
 - Step 2: Run

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
-# k2cli
-k2cli is a command-line interface for [K2](https://github.com/samsung-cnct/k2).
-
-Auto-generated reference documentation can be found [here](docs/k2cli.md).
+# Kraken
+Kraken is a command-line interface for [Krakenlib](https://github.com/samsung-cnct/k2).
 
 ## Getting Started
-This Getting Started guide describes a Kubernetes deployment to AWS. K2 currently also supports deployments to GKE, but not
+This Getting Started guide describes a Kubernetes deployment to AWS. Krakenlib currently also supports deployments to GKE, but not
 by default.
 
 ### Requirements
-Docker must be installed on the machine where you run k2cli, and your user must have permissions to run it.
+Docker must be installed on the machine where you run Kraken, and your user must have permissions to run it.
 
 ### Installing/Fetching the Official Build
 Installation on OSX can happen via Brew by:
@@ -21,37 +19,37 @@ brew install k2cli
 Otherwise, the latest official build can be found here: https://github.com/samsung-cnct/k2cli/releases. You should use the latest version unless you have a specific reason to use a different version.
 
 ### Building a Configuration File
-K2 uses a yaml configuration file for all aspects of the both the Kubernetes cluster and the infrastructure that is
+Krakenlib uses a yaml configuration file for all aspects of the both the Kubernetes cluster and the infrastructure that is
 running it. To build a generic AWS configuration file that has a large number of sensible defaults, you can run:
 ```
-k2cli generate
+kraken generate
 ```
-which will create a file at `${HOME}/.kraken/config.yaml`  **Note:** If a config file already exists the `generate` subcommand will fail with the message: `A K2 config file already exists at <your config location> - rename, delete or move it to generate a new default K2 config file`
+which will create a file at `${HOME}/.kraken/config.yaml`  **Note:** If a config file already exists the `generate` subcommand will fail with the message: `A Krakenlib config file already exists at <your config location> - rename, delete or move it to generate a new default Krakenlib config file`
 
 Or you may specify a path with:
 ```
-k2cli generate ${HOME}/k2configs/
+kraken generate ${HOME}/krakenlibconfigs/
 ```
-which will create a file at `${HOME}/k2configs/config.yaml`.
+which will create a file at `${HOME}/krakenlibconfigs/config.yaml`.
 
 For a GKE configuration file, run:
 ```
-k2cli generate --provider gke
+kraken generate --provider gke
 ```
 
 #### Required Configuration Changes
 For an AWS cluster there are several fields that need to be set before this file can be used:
-*  **Cluster name**  All K2 clusters should have a unique name so their assets can be easily identified by humans in the
+*  **Cluster name**  All Krakenlib clusters should have a unique name so their assets can be easily identified by humans in the
 AWS console (no more than 13 characters). The cluster name is set in the `deployment.clusters.name` field.  This dotted notation refers to the hierarchical structure of a yaml file where cluster is a sub field of deployment. This line is towards the bottom of the file in the `deployment` section.
 
 The following fields are in the `definitions` section of the configuration file.
-In lieu of specifying all of the following, you may just put your credentials file and K2 will grab the authentication specs from there.
+In lieu of specifying all of the following, you may just put your credentials file and Krakenlib will grab the authentication specs from there.
 *  **AWS access key**  Your AWS access key is required for programmatic access to AWS. The field is named
 `providerConfigs.authentication.accessKey`. This can be either set to the literal value, or to an environment
-variable that K2 will use.
+variable that Krakenlib will use.
 *  **AWS access secret**  This is your AWS access secret that is paired to the above access key. This field is named
 `providerConfigs.authentication.accessSecret`. This can be either set to the literal value, or to an environment
-variable that K2 will use.
+variable that Krakenlib will use.
 *  **AWS credentials file**  This is your AWS credentials file that is paired to the below profile. The field is named
 `providerConfigs.authentication.credentialsFile`. This file and path must exist bind mounted to /root
 inside the container, ie. ${HOME}/.aws/credentials.
@@ -122,19 +120,19 @@ yaml:
 To create your first cluster, run the following command. (This assumes you have a configuration built as described above.)
 If you have used the default config location:
 ```
-k2cli cluster up
+kraken cluster up
 ```
 Or you may specify the location of the config file:
 ```
-k2cli cluster up ${HOME}/k2configs/config.yaml
+kraken cluster up ${HOME}/krakenlibconfigs/config.yaml
 ```
 This will take anywhere from five to twenty minutes depending on how AWS is feeling when you execute this command. When
 complete the cluster will exist in its own VPC and will be accesible via the `tool` subcommands. The output artifacts
 will be stored in the default location: `${HOME}/.kraken/<cluster name>`.
 
-### Working with Your Cluster (using k2cli)
-k2cli uses the K2 image (github.com/samsung_cnct/k2) for all of its operations. The K2 image ships with `kubectl` and `helm`
-installed and through the `k2cli tool` subcommand you can access these tools. Using the `k2cli tool` subcommand helps ensure you are
+### Working with Your Cluster (using Kraken)
+Kraken uses the Krakenlib image (github.com/samsung_cnct/k2) for all of its operations. The Krakenlib image ships with `kubectl` and `helm`
+installed and through the `kraken tool` subcommand you can access these tools. Using the `kraken tool` subcommand helps ensure you are
 using the correct version of the relevant CLI for your cluster.
 
 `kubectl` (http://kubernetes.io/docs/user-guide/kubectl-overview/) is a CLI for working with a Kubernetes cluster. It is
@@ -143,30 +141,30 @@ used for deploying application, checking system status and more. See the linked 
 `helm` (https://github.com/kubernetes/helm) is a CLI for deploying and packaging applications to deploy
 to Kubernetes. See the linked documentation for more details.
 
-#### Example Usage - k2cli tool kubectl
+#### Example Usage - Kraken tool kubectl
 
 If you have specified a path for your config.yaml, then you will need to include the `--config ${HOME}/path_to_config/config.yaml` option when running the following commands. Otherwise it will assume your config lives at `${HOME}/.kraken/config.yaml`
 
 To see all nodes in your Kubernetes cluster (and specify path to config file):
 
 ```
-k2cli tool kubectl --config ${HOME}/k2configs/config.yaml get nodes
+kraken tool kubectl --config ${HOME}/krakenlibconfigs/config.yaml get nodes
 ```
 
 To see all installed applications across all namespaces:
 ```
-k2cli tool kubectl --config ${HOME}/k2configs/config.yaml -- get pods --all-namespaces
+kraken tool kubectl --config ${HOME}/krakenlibconfigs/config.yaml -- get pods --all-namespaces
 ```
 
-#### Example usage - k2cli tool helm
+#### Example usage - Kraken tool helm
 To list all installed charts with default config.yaml location:
 ```
-k2cli tool helm list
+kraken tool helm list
 ```
 
 To install the Kafka chart maintained by Samsung CNCT.
 ```
-k2cli tool helm install atlas/kafka
+kraken tool helm install atlas/kafka
 ```
 
 ### Working with your cluster (using host installed tools)
@@ -199,22 +197,22 @@ KUBECONFIG=${HOME}/.kraken/<cluster name>/admin.kubeconfig HELM_HOME=${HOME}/.kr
 ```
 
 ### Updating your cluster
-You may update your nodepools with k2cli, specifically the Kubernetes version, the nodepool counts and instance types. To do so, please make desired changes in your configuration file, and then run k2cli's cluster update command, as described below, pointing to your configuration file.
+You may update your nodepools with Kraken, specifically the Kubernetes version, the nodepool counts and instance types. To do so, please make desired changes in your configuration file, and then run Kraken's cluster update command, as described below, pointing to your configuration file.
 
-#### Running K2cli update
-You can specify different versions of Kubernetes in each nodepool. Note: this may affect the compatibility of your cluster's K2-provided services. Specify which nodepools you wish to update with a comma-separated list of the names of the nodepools. Please be patient; this process may take a while; about ten minutes per node.
+#### Running Kraken update
+You can specify different versions of Kubernetes in each nodepool. Note: this may affect the compatibility of your cluster's Krakenlib-provided services. Specify which nodepools you wish to update with a comma-separated list of the names of the nodepools. Please be patient; this process may take a while; about ten minutes per node.
 
 - Step 1: Make appropriate changes to configuration file
 - Step 2: Run
 ```bash
-k2cli cluster update ${HOME}/k2configs/config.yaml <your,nodepools,here>
+kraken cluster update ${HOME}/krakenlibconfigs/config.yaml <your,nodepools,here>
 ```
 
 ### Destroying the running cluster
 While not something to be done in production, during development when you are done with your cluster (or with a quickstart) it's
 best to clean up your resources. To destroy the running cluster from this guide, simply run:
 ```
-k2cli cluster down ${HOME}/k2configs/config.yaml
+kraken cluster down ${HOME}/kkrakenlibconfigs/config.yaml
 ```
 
 **Note:** if you have specified an '--output' directory during the creation command, make sure you specify it here or the cluster
@@ -222,7 +220,7 @@ will still be running!
 
 ## Note on using environment variables in yaml configuration
 
-k2cli will automatically attempt to expand all ```$VARIABLE_NAME``` strings in your configuration file. It will pass the variable and value to the K2 Docker container, and mount the path (if it's a path to an existing file or folder) into the K2 Docker container.
+Kraken will automatically attempt to expand all ```$VARIABLE_NAME``` strings in your configuration file. It will pass the variable and value to the Krakenlib Docker container, and mount the path (if it's a path to an existing file or folder) into the Krakenlib Docker container.
 ### Environment variable expansion
 
 For example, given a variable such as ```export MY_SERVICE_ACCOUNT_KEYFILE=/Users/kraken/.ssh/keyfile.json```, the configuration:
@@ -261,13 +259,13 @@ deployment:
 ...
 ```
 
-and the K2 Docker container would get a ```/Users/kraken/.ssh/keyfile.json:/Users/kraken/.ssh/keyfile.json``` mount and a ```K2_SERVICE_ACCOUNT_KEYFILE=/Users/kraken/.ssh/keyfile.json``` environment variable
+and the KRAKENLIB Docker container would get a ```/Users/kraken/.ssh/keyfile.json:/Users/kraken/.ssh/keyfile.json``` mount and a ```KRAKENLIB_SERVICE_ACCOUNT_KEYFILE=/Users/kraken/.ssh/keyfile.json``` environment variable
 
 ### Automatic binding of environment variables
 
-Environment variables with a `K2` prefix can also bind automatically to configuration values.
+Environment variables with a `KRAKENLIB` prefix can also bind automatically to configuration values.
 
-For example, given that ```export K2_DEPLOYMENT_CLUSTER=production-cluster```, the configuration:
+For example, given that ```export KRAKENLIB_DEPLOYMENT_CLUSTER=production-cluster```, the configuration:
 
 ```
 deployment:
@@ -308,7 +306,7 @@ If you have further questions or needs please read through the rest of the docs 
 
 ## Developing features or bugfixes
 We accept pull requests from all users and do not require a contributor license agreement. To simplify merging we prefer pull requests that are based on the current Master
-and from a feature branch in your personal fork of the k2cli repo.
+and from a feature branch in your personal fork of the Kraken repo.
 
 ### To build
 This is a go project with vendored dependencies so building is a snap.
@@ -319,10 +317,10 @@ cd k2cli
 go build
 ```
 
-This will create a k2cli binary that can be executed directly like so:
+This will create a Kraken binary that can be executed directly like so:
 
 ```
-./k2cli
+./kraken
 ```
 
 ## Cutting a release

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ kraken generate --provider gke
 #### Required Configuration Changes
 For an AWS cluster there are several fields that need to be set before this file can be used:
 *  **Cluster name**  All Kraken clusters should have a unique name so their assets can be easily identified by humans in the
-AWS console (no more than 13 characters). The cluster name is set in the `deployment.clusters.name` field.  This dotted notation refers to the hierarchical structure of a yaml file where cluster is a sub field of deployment. This line is towards the bottom of the file in the `deployment` section.
+AWS console (no more than 32 characters). The cluster name is set in the `deployment.clusters.name` field.  This dotted notation refers to the hierarchical structure of a yaml file where cluster is a sub field of deployment. This line is towards the bottom of the file in the `deployment` section.
 
 The following fields are in the `definitions` section of the configuration file.
-In lieu of specifying all of the following, you may just put your credentials file and Kraken will grab the authentication specs from there.
+In lieu of specifying all of the following, you may just put your credentials in the AWS credentials file and Kraken will grab the authentication specs from there.
 *  **AWS access key**  Your AWS access key is required for programmatic access to AWS. The field is named
 `providerConfigs.authentication.accessKey`. This can be either set to the literal value, or to an environment
 variable that Kraken will use.
@@ -211,7 +211,7 @@ kraken cluster update ${HOME}/krakenlibconfigs/config.yaml <your,nodepools,here>
 While not something to be done in production, during development when you are done with your cluster (or with a quickstart) it's
 best to clean up your resources. To destroy the running cluster from this guide, simply run:
 ```
-kraken cluster down ${HOME}/kkrakenlibconfigs/config.yaml
+kraken cluster down ${HOME}/krakenConfigs/config.yaml
 ```
 
 **Note:** if you have specified an '--output' directory during the creation command, make sure you specify it here or the cluster

--- a/build-scripts/fetch-credentials.sh
+++ b/build-scripts/fetch-credentials.sh
@@ -1,4 +1,4 @@
-#  this script fetches all credentials to support the building of a k2 cluster
+#  this script fetches all credentials to support the building of a Kraken cluster
 #  for now this includes:
 #   - an ssh key pair
 #   - aws credentials file

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -39,7 +39,7 @@ func init() {
 	RootCmd.AddCommand(clusterCmd)
 
 	clusterCmd.PersistentFlags().StringVarP(
-		&k2ConfigPath,
+		&krakenlibConfigPath,
 		"config",
 		"c",
 		os.ExpandEnv("$HOME/.kraken/config.yaml"),

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -15,20 +15,20 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 var userName string
 var password string
 var configForced bool
 
-
 // clusterCmd represents the cluster command
 var clusterCmd = &cobra.Command{
 	Use:   "cluster",
-	Short: "K2 cluster actions",
-	Long:  `Commands that perform actions on a K2 cluster described by a provided yaml config`,
+	Short: "Krakenlib cluster actions",
+	Long:  `Commands that perform actions on a Krakenlib cluster described by a provided yaml config`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Usage()
 		ExitCode = 1

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -39,7 +39,7 @@ func init() {
 	RootCmd.AddCommand(clusterCmd)
 
 	clusterCmd.PersistentFlags().StringVarP(
-		&krakenlibConfigPath,
+		&ClusterConfigPath,
 		"config",
 		"c",
 		os.ExpandEnv("$HOME/.kraken/config.yaml"),

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -27,8 +27,8 @@ var configForced bool
 // clusterCmd represents the cluster command
 var clusterCmd = &cobra.Command{
 	Use:   "cluster",
-	Short: "Krakenlib cluster actions",
-	Long:  `Commands that perform actions on a Krakenlib cluster described by a provided yaml config`,
+	Short: "Kraken cluster actions",
+	Long:  `Commands that perform actions on a Kraken cluster described by a provided yaml config`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Usage()
 		ExitCode = 1

--- a/cmd/cluster_down.go
+++ b/cmd/cluster_down.go
@@ -57,7 +57,7 @@ var downCmd = &cobra.Command{
 		ctx, cancel := getTimedContext()
 		defer cancel()
 
-		resp, statusCode, timeout, err := containerAction(cli, ctx, command, krakenConfigPath)
+		resp, statusCode, timeout, err := containerAction(cli, ctx, command, krakenlibConfigPath)
 		if err != nil {
 			return err
 		}

--- a/cmd/cluster_down.go
+++ b/cmd/cluster_down.go
@@ -31,7 +31,7 @@ var downCmd = &cobra.Command{
 	SilenceErrors: true,
 	SilenceUsage:  true,
 	Long:          `Destroys a Kraken cluster described in the specified configuration yaml`,
-	PreRunE:       preRunGetKrakenConfig,
+	PreRunE:       preRunGetClusterConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cli, backgroundCtx, err := pullKrakenContainerImage(containerImage)
 		if err != nil {
@@ -49,7 +49,7 @@ var downCmd = &cobra.Command{
 			"ansible/inventory/localhost",
 			"ansible/down.yaml",
 			"--extra-vars",
-			"config_path=" + krakenlibConfigPath + " config_base=" + outputLocation + " config_forced=" + strconv.FormatBool(configForced) + " kraken_action=down ",
+			"config_path=" + ClusterConfigPath + " config_base=" + outputLocation + " config_forced=" + strconv.FormatBool(configForced) + " kraken_action=down ",
 			"--tags",
 			downStagesList,
 		}
@@ -57,7 +57,7 @@ var downCmd = &cobra.Command{
 		ctx, cancel := getTimedContext()
 		defer cancel()
 
-		resp, statusCode, timeout, err := containerAction(cli, ctx, command, krakenlibConfigPath)
+		resp, statusCode, timeout, err := containerAction(cli, ctx, command, ClusterConfigPath)
 		if err != nil {
 			return err
 		}

--- a/cmd/cluster_down.go
+++ b/cmd/cluster_down.go
@@ -107,5 +107,5 @@ func init() {
 		"stages",
 		"s",
 		"all",
-		"comma-separated list of Krakenlib stages to run: [all, dryrun, config, fabric, master, node, assembler, readiness, services]")
+		"comma-separated list of Kraken stages to run: [all, dryrun, config, fabric, master, node, assembler, readiness, services]")
 }

--- a/cmd/cluster_down.go
+++ b/cmd/cluster_down.go
@@ -16,20 +16,21 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"strconv"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 var downStagesList string
 
 // downCmd represents the down command
 var downCmd = &cobra.Command{
-	Use:           "down [path to K2 config file]",
-	Short:         "destroy a K2 cluster",
+	Use:           "down [path to Kraken config file]",
+	Short:         "destroy a Kraken cluster",
 	SilenceErrors: true,
 	SilenceUsage:  true,
-	Long:          `Destroys a K2 cluster described in the specified configuration yaml`,
+	Long:          `Destroys a Kraken cluster described in the specified configuration yaml`,
 	PreRunE:       preRunGetKrakenConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cli, backgroundCtx, err := pullKrakenContainerImage(containerImage)
@@ -48,7 +49,7 @@ var downCmd = &cobra.Command{
 			"ansible/inventory/localhost",
 			"ansible/down.yaml",
 			"--extra-vars",
-			"config_path=" + k2ConfigPath + " config_base=" + outputLocation + " config_forced=" + strconv.FormatBool(configForced) + " kraken_action=down ",
+			"config_path=" + krakenlibConfigPath + " config_base=" + outputLocation + " config_forced=" + strconv.FormatBool(configForced) + " kraken_action=down ",
 			"--tags",
 			downStagesList,
 		}
@@ -56,7 +57,7 @@ var downCmd = &cobra.Command{
 		ctx, cancel := getTimedContext()
 		defer cancel()
 
-		resp, statusCode, timeout, err := containerAction(cli, ctx, command, k2ConfigPath)
+		resp, statusCode, timeout, err := containerAction(cli, ctx, command, krakenConfigPath)
 		if err != nil {
 			return err
 		}
@@ -106,5 +107,5 @@ func init() {
 		"stages",
 		"s",
 		"all",
-		"comma-separated list of K2 stages to run: [all, dryrun, config, fabric, master, node, assembler, readiness, services]")
+		"comma-separated list of Krakenlib stages to run: [all, dryrun, config, fabric, master, node, assembler, readiness, services]")
 }

--- a/cmd/cluster_helper.go
+++ b/cmd/cluster_helper.go
@@ -9,21 +9,21 @@ import (
 	"golang.org/x/net/context"
 )
 
-func preRunGetKrakenConfig(cmd *cobra.Command, args []string) error {
+func preRunGetClusterConfig(cmd *cobra.Command, args []string) error {
 	if !cmd.Flag("config").Changed {
-		fmt.Printf("config file path not given, using default config file location (%s)\n", krakenlibConfigPath)
+		fmt.Printf("config file path not given, using default config file location (%s)\n", ClusterConfigPath)
 	}
 
-	_, err := os.Stat(krakenlibConfigPath)
+	_, err := os.Stat(ClusterConfigPath)
 	if os.IsNotExist(err) {
-		return fmt.Errorf("File %s does not exist!", krakenlibConfigPath)
+		return fmt.Errorf("File %s does not exist!", ClusterConfigPath)
 	}
 
 	if err != nil {
 		return err
 	}
 
-	if err := initKrakenClusterConfig(krakenlibConfigPath); err != nil {
+	if err := initClusterConfig(ClusterConfigPath); err != nil {
 		return err
 	}
 

--- a/cmd/cluster_helper.go
+++ b/cmd/cluster_helper.go
@@ -11,28 +11,27 @@ import (
 
 func preRunGetKrakenConfig(cmd *cobra.Command, args []string) error {
 	if !cmd.Flag("config").Changed {
-		fmt.Printf("config file path not given, using default config file location (%s)\n", k2ConfigPath)
+		fmt.Printf("config file path not given, using default config file location (%s)\n", krakenlibConfigPath)
 	}
 
-	_, err := os.Stat(k2ConfigPath)
+	_, err := os.Stat(krakenlibConfigPath)
 	if os.IsNotExist(err) {
-		return fmt.Errorf("File %s does not exist!", k2ConfigPath)
+		return fmt.Errorf("File %s does not exist!", krakenlibConfigPath)
 	}
 
 	if err != nil {
 		return err
 	}
 
-	if err := initKrakenClusterConfig(k2ConfigPath); err != nil {
+	if err := initKrakenClusterConfig(krakenlibConfigPath); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-
 func pullKrakenContainerImage(containerImage string) (*client.Client, context.Context, error) {
-	terminalSpinner.Prefix = fmt.Sprintf("Pulling image '%s' ",containerImage)
+	terminalSpinner.Prefix = fmt.Sprintf("Pulling image '%s' ", containerImage)
 	terminalSpinner.Start()
 
 	cli, err := getClient()

--- a/cmd/cluster_info.go
+++ b/cmd/cluster_info.go
@@ -26,9 +26,9 @@ var infoCmd = &cobra.Command{
 	SilenceUsage:  true,
 	Long: `Output some basic information on the current
 	cluster state configured by the specified Krakenlib yaml`,
-	PreRunE: preRunGetKrakenConfig,
+	PreRunE: preRunGetClusterConfig,
 	Run: func(cmd *cobra.Command, args []string) {
-		clusterHelpError(Created, krakenlibConfigPath)
+		clusterHelpError(Created, ClusterConfigPath)
 		ExitCode = 0
 	},
 }

--- a/cmd/cluster_info.go
+++ b/cmd/cluster_info.go
@@ -24,11 +24,11 @@ var infoCmd = &cobra.Command{
 	Short:         "Print out cluster state information",
 	SilenceErrors: true,
 	SilenceUsage:  true,
-	Long: `Output some basic information on the current 
-	cluster state configured by the specified K2 yaml`,
+	Long: `Output some basic information on the current
+	cluster state configured by the specified Krakenlib yaml`,
 	PreRunE: preRunGetKrakenConfig,
 	Run: func(cmd *cobra.Command, args []string) {
-		clusterHelpError(Created, k2ConfigPath)
+		clusterHelpError(Created, krakenlibConfigPath)
 		ExitCode = 0
 	},
 }

--- a/cmd/cluster_up.go
+++ b/cmd/cluster_up.go
@@ -26,8 +26,8 @@ var upStagesList string
 
 // upCmd represents the up command
 var upCmd = &cobra.Command{
-	Use:           "up [path to Krakenlib config file]",
-	Short:         "create a Krakenlib cluster",
+	Use:           "up [path to Kraken config file]",
+	Short:         "create a Kraken cluster",
 	SilenceErrors: true,
 	SilenceUsage:  true,
 	Long:          `Creates a K2 cluster described in the specified configuration yaml`,
@@ -103,5 +103,5 @@ func init() {
 		"stages",
 		"s",
 		"all",
-		"comma-separated list of Krakenlib stages to run. Run 'kraken help topic stages' for more info.")
+		"comma-separated list of Kraken stages to run. Run 'kraken help topic stages' for more info.")
 }

--- a/cmd/cluster_up.go
+++ b/cmd/cluster_up.go
@@ -20,15 +20,14 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-
 )
 
 var upStagesList string
 
 // upCmd represents the up command
 var upCmd = &cobra.Command{
-	Use:           "up [path to K2 config file]",
-	Short:         "create a K2 cluster",
+	Use:           "up [path to Krakenlib config file]",
+	Short:         "create a Krakenlib cluster",
 	SilenceErrors: true,
 	SilenceUsage:  true,
 	Long:          `Creates a K2 cluster described in the specified configuration yaml`,
@@ -50,7 +49,7 @@ var upCmd = &cobra.Command{
 			"ansible/inventory/localhost",
 			"ansible/up.yaml",
 			"--extra-vars",
-			"config_path=" + k2ConfigPath + " config_base=" + outputLocation + " config_forced=" + strconv.FormatBool(configForced) + " kraken_action=up ",
+			"config_path=" + krakenlibConfigPath + " config_base=" + outputLocation + " config_forced=" + strconv.FormatBool(configForced) + " kraken_action=up ",
 			"--tags",
 			upStagesList,
 		}
@@ -58,7 +57,7 @@ var upCmd = &cobra.Command{
 		ctx, cancel := getTimedContext()
 		defer cancel()
 
-		resp, statusCode, timeout, err := containerAction(cli, ctx, command, k2ConfigPath)
+		resp, statusCode, timeout, err := containerAction(cli, ctx, command, krakenlibConfigPath)
 		if err != nil {
 			return err
 		}
@@ -83,13 +82,13 @@ var upCmd = &cobra.Command{
 		if statusCode != 0 {
 			fmt.Println("ERROR bringing up " + getContainerName())
 			fmt.Printf("%s", out)
-			clusterHelpError(Created, k2ConfigPath)
+			clusterHelpError(Created, krakenlibConfigPath)
 		} else {
 			fmt.Println("Done.")
 			if logSuccess {
 				fmt.Printf("%s", out)
 			}
-			clusterHelp(Created, k2ConfigPath)
+			clusterHelp(Created, krakenlibConfigPath)
 		}
 
 		ExitCode = statusCode
@@ -104,5 +103,5 @@ func init() {
 		"stages",
 		"s",
 		"all",
-		"comma-separated list of K2 stages to run. Run 'k2cli help topic stages' for more info.")
+		"comma-separated list of Krakenlib stages to run. Run 'kraken help topic stages' for more info.")
 }

--- a/cmd/cluster_up.go
+++ b/cmd/cluster_up.go
@@ -27,10 +27,10 @@ var upStagesList string
 // upCmd represents the up command
 var upCmd = &cobra.Command{
 	Use:           "up [path to Kraken config file]",
-	Short:         "create a Kraken cluster",
+	Short:         "Creates a Kraken cluster",
 	SilenceErrors: true,
 	SilenceUsage:  true,
-	Long:          `Creates a K2 cluster described in the specified configuration yaml`,
+	Long:          `Creates a Kraken cluster described in the specified configuration yaml`,
 	PreRunE:       preRunGetKrakenConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cli, backgroundCtx, err := pullKrakenContainerImage(containerImage)

--- a/cmd/cluster_up.go
+++ b/cmd/cluster_up.go
@@ -31,7 +31,7 @@ var upCmd = &cobra.Command{
 	SilenceErrors: true,
 	SilenceUsage:  true,
 	Long:          `Creates a Kraken cluster described in the specified configuration yaml`,
-	PreRunE:       preRunGetKrakenConfig,
+	PreRunE:       preRunGetClusterConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cli, backgroundCtx, err := pullKrakenContainerImage(containerImage)
 		if err != nil {
@@ -49,7 +49,7 @@ var upCmd = &cobra.Command{
 			"ansible/inventory/localhost",
 			"ansible/up.yaml",
 			"--extra-vars",
-			"config_path=" + krakenlibConfigPath + " config_base=" + outputLocation + " config_forced=" + strconv.FormatBool(configForced) + " kraken_action=up ",
+			"config_path=" + ClusterConfigPath + " config_base=" + outputLocation + " config_forced=" + strconv.FormatBool(configForced) + " kraken_action=up ",
 			"--tags",
 			upStagesList,
 		}
@@ -57,7 +57,7 @@ var upCmd = &cobra.Command{
 		ctx, cancel := getTimedContext()
 		defer cancel()
 
-		resp, statusCode, timeout, err := containerAction(cli, ctx, command, krakenlibConfigPath)
+		resp, statusCode, timeout, err := containerAction(cli, ctx, command, ClusterConfigPath)
 		if err != nil {
 			return err
 		}
@@ -82,13 +82,13 @@ var upCmd = &cobra.Command{
 		if statusCode != 0 {
 			fmt.Println("ERROR bringing up " + getContainerName())
 			fmt.Printf("%s", out)
-			clusterHelpError(Created, krakenlibConfigPath)
+			clusterHelpError(Created, ClusterConfigPath)
 		} else {
 			fmt.Println("Done.")
 			if logSuccess {
 				fmt.Printf("%s", out)
 			}
-			clusterHelp(Created, krakenlibConfigPath)
+			clusterHelp(Created, ClusterConfigPath)
 		}
 
 		ExitCode = statusCode

--- a/cmd/cluster_update.go
+++ b/cmd/cluster_update.go
@@ -29,36 +29,35 @@ var rmNodepools string
 
 // updateCmd represents the update command
 var updateCmd = &cobra.Command{
-	Use:           "update [path to K2 config file]",
-	Short:         "update a K2 cluster",
+	Use:           "update [path to krakenlib config file]",
+	Short:         "update a Krakenlib cluster",
 	SilenceErrors: true,
 	SilenceUsage:  true,
-	Long:          `Updates a K2 cluster described in the specified configuration yaml`,
+	Long:          `Updates a Krakenlib cluster described in the specified configuration yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		k2ConfigPath = os.ExpandEnv("$HOME/.kraken/config.yaml")
+		krakenlibConfigPath = os.ExpandEnv("$HOME/.kraken/config.yaml")
 		if len(args) > 0 {
-			k2ConfigPath = os.ExpandEnv(args[0])
+			krakenlibConfigPath = os.ExpandEnv(args[0])
 		}
 
 		if updateNodepools == "" && addNodepools == "" && rmNodepools == "" {
 			return fmt.Errorf("You must specify which nodepools you want to update. Please pass a comma-separated list of nodepools to update-nodepools, " +
-			"add-nodepools or rm-nodepools depending on what action you are taking against the nodepools.  For example: \n k2cli cluster update " +
-			"--update-nodepools masterNodes,clusterNodes,otherNodes --rm-nodepools badNodepool")
+				"add-nodepools or rm-nodepools depending on what action you are taking against the nodepools.  For example: \n kraken cluster update " +
+				"--update-nodepools masterNodes,clusterNodes,otherNodes --rm-nodepools badNodepool")
 		}
 
-		_, err := os.Stat(k2ConfigPath)
+		_, err := os.Stat(krakenlibConfigPath)
 		if os.IsNotExist(err) {
-			return errors.New("File " + k2ConfigPath + " does not exist!")
+			return errors.New("File " + krakenlibConfigPath + " does not exist!")
 		}
 
 		if err != nil {
 			return err
 		}
 
-		if err := initKrakenClusterConfig(k2ConfigPath); err != nil {
+		if err := initKrakenClusterConfig(krakenConfigPath); err != nil {
 			return err
 		}
-
 
 		return nil
 	},
@@ -77,13 +76,13 @@ var updateCmd = &cobra.Command{
 			"ansible/inventory/localhost",
 			"ansible/update.yaml",
 			"--extra-vars",
-			"config_path=" + k2ConfigPath + " config_base=" + outputLocation + " kraken_action=update " + " update_nodepools=" + updateNodepools + 
-			" add_nodepools=" + addNodepools + " remove_nodepools=" + rmNodepools,
+			"config_path=" + krakenlibConfigPath + " config_base=" + outputLocation + " kraken_action=update " + " update_nodepools=" + updateNodepools +
+				" add_nodepools=" + addNodepools + " remove_nodepools=" + rmNodepools,
 		}
 
 		ctx := getContext()
 		// defer cancel()
-		resp, statusCode, timeout, err := containerAction(cli, ctx, command, k2ConfigPath)
+		resp, statusCode, timeout, err := containerAction(cli, ctx, command, krakenlibConfigPath)
 		if err != nil {
 			return err
 		}
@@ -106,13 +105,13 @@ var updateCmd = &cobra.Command{
 		if statusCode != 0 {
 			fmt.Println("ERROR updating " + getContainerName())
 			fmt.Printf("%s", out)
-			clusterHelpError(Created, k2ConfigPath)
+			clusterHelpError(Created, krakenlibConfigPath)
 		} else {
 			fmt.Println("Done.")
 			if logSuccess {
 				fmt.Printf("%s", out)
 			}
-			clusterHelp(Created, k2ConfigPath)
+			clusterHelp(Created, krakenlibConfigPath)
 		}
 
 		ExitCode = statusCode

--- a/cmd/cluster_update.go
+++ b/cmd/cluster_update.go
@@ -29,11 +29,11 @@ var rmNodepools string
 
 // updateCmd represents the update command
 var updateCmd = &cobra.Command{
-	Use:           "update [path to krakenlib config file]",
-	Short:         "update a Krakenlib cluster",
+	Use:           "update [path to kraken config file]",
+	Short:         "update a Kraken cluster",
 	SilenceErrors: true,
 	SilenceUsage:  true,
-	Long:          `Updates a Krakenlib cluster described in the specified configuration yaml`,
+	Long:          `Updates a Kraken cluster described in the specified configuration yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		krakenlibConfigPath = os.ExpandEnv("$HOME/.kraken/config.yaml")
 		if len(args) > 0 {

--- a/cmd/cluster_update.go
+++ b/cmd/cluster_update.go
@@ -55,7 +55,7 @@ var updateCmd = &cobra.Command{
 			return err
 		}
 
-		if err := initKrakenClusterConfig(krakenConfigPath); err != nil {
+		if err := initKrakenClusterConfig(krakenlibConfigPath); err != nil {
 			return err
 		}
 

--- a/cmd/container_helpers.go
+++ b/cmd/container_helpers.go
@@ -197,7 +197,7 @@ func makeMounts(clusterConfigPath string) (*container.HostConfig, []string) {
 				outputLocation + ":" + outputLocation},
 		}
 
-		deployment := reflect.ValueOf(krakenClusterConfig.Sub("deployment"))
+		deployment := reflect.ValueOf(clusterConfig.Sub("deployment"))
 		parseMounts(deployment, hostConfig, &config_envs)
 
 	} else {
@@ -631,7 +631,7 @@ func writeLog(logFilePath string, out []byte) error {
 
 func getContainerName() string {
 	// only supports first cluster name right now
-	clusters := krakenClusterConfig.Get("deployment.clusters")
+	clusters := clusterConfig.Get("deployment.clusters")
 	if clusters != nil {
 		firstCluster := clusters.([]interface{})[0].(map[interface{}]interface{})
 		if firstCluster["name"] == nil {

--- a/cmd/container_helpers.go
+++ b/cmd/container_helpers.go
@@ -126,7 +126,7 @@ func clusterHelp(help helptype, clusterConfigFile string) {
 		fmt.Println(" kubectl --kubeconfig=" + path.Join(
 			outputLocation,
 			getContainerName(), "admin.kubeconfig") + " [kubectl commands]")
-		fmt.Println(" or use 'k2cli tool kubectl --config " + clusterConfigFile + " [kubectl commands]'")
+		fmt.Println(" or use 'kraken tool kubectl --config " + clusterConfigFile + " [kubectl commands]'")
 
 		if _, err := os.Stat(path.Join(outputLocation,
 			getContainerName(), "admin.kubeconfig")); err == nil {
@@ -137,7 +137,7 @@ func clusterHelp(help helptype, clusterConfigFile string) {
 			fmt.Println(" helm [helm command] --home " + path.Join(
 				outputLocation,
 				getContainerName(), ".helm"))
-			fmt.Println(" or use 'k2cli tool helm --config " + clusterConfigFile + " [helm commands]'")
+			fmt.Println(" or use 'kraken tool helm --config " + clusterConfigFile + " [helm commands]'")
 		}
 	}
 
@@ -148,7 +148,7 @@ func clusterHelp(help helptype, clusterConfigFile string) {
 			outputLocation,
 			getContainerName(), "ssh_config"))
 		// This is usage has not been implemented. See issue #49
-		//fmt.Println(" or use 'k2cli tool --config ssh ssh " + clusterConfigFile + " [ssh commands]'")
+		//fmt.Println(" or use 'kraken tool --config ssh ssh " + clusterConfigFile + " [ssh commands]'")
 	}
 }
 
@@ -484,10 +484,10 @@ func pullImage(cli *client.Client, ctx context.Context, base64Auth string) error
 	return nil
 }
 
-func containerAction(cli *client.Client, ctx context.Context, command []string, k2config string) (types.ContainerCreateResponse, int, func(), error) {
+func containerAction(cli *client.Client, ctx context.Context, command []string, krakenlibconfig string) (types.ContainerCreateResponse, int, func(), error) {
 	var containerResponse types.ContainerCreateResponse
 
-	hostConfig, config_envs := makeMounts(k2config)
+	hostConfig, config_envs := makeMounts(krakenlibconfig)
 	containerConfig := &container.Config{
 		Image:        containerImage,
 		Env:          append(containerEnvironment(), config_envs...),
@@ -500,7 +500,7 @@ func containerAction(cli *client.Client, ctx context.Context, command []string, 
 	//  clusterName can be empty as a valid thing when a user is generating a config so the
 	//  hardcoded base portion of the name must satisfy the above regex.
 	clusterName := getContainerName()
-	resp, err := cli.ContainerCreate(ctx, containerConfig, hostConfig, nil, "k2"+clusterName)
+	resp, err := cli.ContainerCreate(ctx, containerConfig, hostConfig, nil, "krakenlib"+clusterName)
 	if err != nil {
 		return containerResponse, -1, nil, err
 	}
@@ -531,12 +531,12 @@ func containerAction(cli *client.Client, ctx context.Context, command []string, 
 						panic(removeErr)
 					}
 
-					newContainerName := "k2-" + namesgenerator.GetRandomName(1)
+					newContainerName := "krakenlib-" + namesgenerator.GetRandomName(1)
 					removeErr = cli.ContainerRename(
 						getContext(),
 						resp.ID,
 						newContainerName)
-					fmt.Println("Renamed k2-" + clusterName + " to " + newContainerName)
+					fmt.Println("Renamed krakenlib-" + clusterName + " to " + newContainerName)
 				} else {
 					removeErr = cli.ContainerRemove(
 						getContext(),
@@ -559,12 +559,12 @@ func containerAction(cli *client.Client, ctx context.Context, command []string, 
 	return resp, statusCode, func() {
 		var removeErr error
 		if keepAlive {
-			newContainerName := "k2-" + namesgenerator.GetRandomName(1)
+			newContainerName := "krakenlib-" + namesgenerator.GetRandomName(1)
 			removeErr = cli.ContainerRename(
 				getContext(),
 				resp.ID,
 				newContainerName)
-			fmt.Println("Renamed k2-" + clusterName + " to " + newContainerName)
+			fmt.Println("Renamed krakenlib-" + clusterName + " to " + newContainerName)
 		} else {
 			removeErr = cli.ContainerRemove(
 				getContext(),

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -15,9 +15,10 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
-	"os"
 )
 
 var docPath string
@@ -27,7 +28,7 @@ var docsCmd = &cobra.Command{
 	Use:          "docs [output dir]",
 	Short:        "Generate markdown docs",
 	SilenceUsage: true,
-	Long:         `Generate complete markdown doc tree for k2cli`,
+	Long:         `Generate complete markdown doc tree for Kraken`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) > 0 {
 			docPath = os.ExpandEnv(args[0])

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -27,12 +27,12 @@ var provider string
 var configPath string
 
 var generateCmd = &cobra.Command{
-	Use:          "generate [path to save the K2 config file at] (default ) " + os.ExpandEnv("$HOME/.kraken/config.yaml"),
-	Short:        "Generate a K2 config file",
+	Use:          "generate [path to save the Krakenlib config file at] (default ) " + os.ExpandEnv("$HOME/.kraken/config.yaml"),
+	Short:        "Generate a Krakenlib config file",
 	SilenceUsage: true,
-	Long:         `Generate a K2 configuration file at the specified location`,
+	Long:         `Generate a Krakenlib configuration file at the specified location`,
 	PreRunE:      preRunEFunc,
-	RunE:          runFunc,
+	RunE:         runFunc,
 }
 
 func preRunEFunc(cmd *cobra.Command, args []string) error {
@@ -55,7 +55,7 @@ func preRunEFunc(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Attempting to generate configuration at: %s \n", generatePath)
 
 	if _, err := os.Stat(generatePath); !os.IsNotExist(err) {
-		return fmt.Errorf("Attempted to create %s, but the file already exists: rename, delete or move it, then run 'generate' subcommand again to generate a new default K2 config file", generatePath)
+		return fmt.Errorf("Attempted to create %s, but the file already exists: rename, delete or move it, then run 'generate' subcommand again to generate a new default Kraken config file", generatePath)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(generatePath), 0777); err != nil {

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -27,10 +27,10 @@ var provider string
 var configPath string
 
 var generateCmd = &cobra.Command{
-	Use:          "generate [path to save the Krakenlib config file at] (default ) " + os.ExpandEnv("$HOME/.kraken/config.yaml"),
-	Short:        "Generate a Krakenlib config file",
+	Use:          "generate [path to save the Kraken config file at] (default ) " + os.ExpandEnv("$HOME/.kraken/config.yaml"),
+	Short:        "Generate a Kraken config file",
 	SilenceUsage: true,
-	Long:         `Generate a Krakenlib configuration file at the specified location`,
+	Long:         `Generate a Kraken configuration file at the specified location`,
 	PreRunE:      preRunEFunc,
 	RunE:         runFunc,
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,7 @@ var keepAlive bool
 var logPath string
 var logSuccess bool
 var verbosity bool
-var k2Tag string // this is set via linker flag
+var krakenTag string // this is set via linker flag
 
 // to be used by subcommands using --config
 var k2ConfigPath string
@@ -98,20 +98,20 @@ func init() {
 		&cfgFile,
 		"kraken",
 		"k",
-		os.ExpandEnv("$HOME/.k2cli/config.yaml"),
+		os.ExpandEnv("$HOME/.kraken/.kraken/config.yaml"),
 		"Path to kraken config file")
 	RootCmd.PersistentFlags().StringVarP(
 		&containerImage,
 		"image",
 		"i",
-		"quay.io/samsung_cnct/k2:"+k2Tag,
-		"k2 container image")
+		"quay.io/samsung_cnct/k2:"+krakenTag,
+		"Kraken container image")
 	RootCmd.PersistentFlags().StringVarP(
 		&outputLocation,
 		"output",
 		"o",
 		os.Getenv("HOME")+"/.kraken",
-		"Krakenlib output folder")
+		"Kraken output folder")
 
 	// Specify the docker host string; typically unix:///var/run/docker.sock
 	RootCmd.PersistentFlags().StringVarP(

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,7 @@ var keepAlive bool
 var logPath string
 var logSuccess bool
 var verbosity bool
-var k2Tag string  // this is set via linker flag
+var k2Tag string // this is set via linker flag
 
 // to be used by subcommands using --config
 var k2ConfigPath string
@@ -51,10 +51,10 @@ var krakenConfig = viper.New()
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
-	Use:   "k2cli",
-	Short: "CLI for K2 Kubernetes cluster provisioner",
-	Long: `k2cli is a command line interface for K2
-	kubernetes cluster provisioner. K2 documentation is available at:
+	Use:   "kraken",
+	Short: "CLI for Krakenlib Kubernetes cluster provisioner",
+	Long: `kraken is a command line interface for Krakenlib
+	kubernetes cluster provisioner. Krakenlib documentation is available at:
 	https://github.com/samsung-cnct/k2`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if _, err := os.Stat(outputLocation); os.IsNotExist(err) {
@@ -76,7 +76,7 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(initK2CliConfig)
+	cobra.OnInitialize(initKrakenConfig)
 	terminalSpinner.FinalMSG = "Complete\n"
 
 	RootCmd.SetHelpCommand(helpCmd)
@@ -106,14 +106,14 @@ func init() {
 		&containerImage,
 		"image",
 		"i",
-		"quay.io/samsung_cnct/k2:" + k2Tag,
+		"quay.io/samsung_cnct/k2:"+k2Tag,
 		"k2 container image")
 	RootCmd.PersistentFlags().StringVarP(
 		&outputLocation,
 		"output",
 		"o",
 		os.Getenv("HOME")+"/.kraken",
-		"K2 output folder")
+		"Krakenlib output folder")
 
 	// Specify the docker host string; typically unix:///var/run/docker.sock
 	RootCmd.PersistentFlags().StringVarP(
@@ -219,13 +219,10 @@ func initK2CliConfig() {
 	krakenConfig.AddConfigPath("$HOME/.kraken") // adding home directory as first search path
 	krakenConfig.AddConfigPath(".")             // optionally look for config in the working directory
 
-
-
 	cfgFile = krakenConfig.GetString("kraken.config")
 	if cfgFile != "" { // enable ability to specify config file via flag
 		krakenConfig.SetConfigFile(cfgFile)
 	}
-
 
 	// If a config file is found, read it in.
 	if err := krakenConfig.ReadInConfig(); err == nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,13 +38,13 @@ var verbosity bool
 var krakenTag string // this is set via linker flag
 
 // to be used by subcommands using --config
-var krakenlibConfigPath string
+var ClusterConfigPath string
 
 // progress spinner
 var terminalSpinner = spinner.New(spinner.CharSets[35], 200*time.Millisecond)
 
 // init the Krakenlib config viper instance
-var krakenClusterConfig = viper.New()
+var clusterConfig = viper.New()
 
 // init the Kraken config viper instance
 var krakenConfig = viper.New()
@@ -228,17 +228,17 @@ func initKrakenConfig() {
 	}
 }
 
-func initKrakenClusterConfig(krakenlibConfigPath string) error {
-	krakenClusterConfig.SetConfigFile(krakenlibConfigPath)
-	krakenClusterConfig.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	krakenClusterConfig.SetEnvPrefix("krakenlib") // prefix for env vars to configure cluster
-	krakenClusterConfig.AutomaticEnv()            // read in environment variables that match
+func initClusterConfig(ClusterConfigPath string) error {
+	clusterConfig.SetConfigFile(ClusterConfigPath)
+	clusterConfig.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	clusterConfig.SetEnvPrefix("krakenlib") // prefix for env vars to configure cluster
+	clusterConfig.AutomaticEnv()            // read in environment variables that match
 
 	// If a config file is found, read it in.
-	if err := krakenClusterConfig.ReadInConfig(); err != nil {
+	if err := clusterConfig.ReadInConfig(); err != nil {
 		return err
 	}
 
-	fmt.Printf("Using Kraken config file: %s \n", krakenClusterConfig.ConfigFileUsed())
+	fmt.Printf("Using Kraken config file: %s \n", clusterConfig.ConfigFileUsed())
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,10 +52,8 @@ var krakenConfig = viper.New()
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "kraken",
-	Short: "CLI for Krakenlib Kubernetes cluster provisioner",
-	Long: `kraken is a command line interface for Krakenlib
-	kubernetes cluster provisioner. Krakenlib documentation is available at:
-	https://github.com/samsung-cnct/k2`,
+	Short: "Kraken is an orchestration and cluster level management system for Kubernetes",
+	Long:  "Kraken is an orchestration and cluster level management system for Kubernetes that creates a production scale cluster on a range of platforms using its default settings.",
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if _, err := os.Stat(outputLocation); os.IsNotExist(err) {
 			os.Mkdir(outputLocation, 0755)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,15 +38,15 @@ var verbosity bool
 var krakenTag string // this is set via linker flag
 
 // to be used by subcommands using --config
-var k2ConfigPath string
+var krakenlibConfigPath string
 
 // progress spinner
 var terminalSpinner = spinner.New(spinner.CharSets[35], 200*time.Millisecond)
 
-// init the K2 config viper instance
+// init the Krakenlib config viper instance
 var krakenClusterConfig = viper.New()
 
-// init the k2cli config viper instance
+// init the Kraken config viper instance
 var krakenConfig = viper.New()
 
 // RootCmd represents the base command when called without any subcommands
@@ -79,8 +79,8 @@ func init() {
 
 	RootCmd.SetHelpCommand(helpCmd)
 
-	if k2Tag == "" {
-		k2Tag = "latest"
+	if krakenTag == "" {
+		krakenTag = "latest"
 	}
 
 	// Populate the global with a "vanilla" Docker configuration
@@ -189,7 +189,7 @@ func init() {
 }
 
 // initConfig reads in config file and ENV variables if set.
-func initK2CliConfig() {
+func initKrakenConfig() {
 
 	// first bind flags
 	krakenConfig.BindPFlag("kraken.config", RootCmd.Flags().Lookup("kraken"))
@@ -209,8 +209,8 @@ func initK2CliConfig() {
 
 	// Then env. variables
 	krakenConfig.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	krakenConfig.SetEnvPrefix("k2cli") // prefix for env vars to configure client itself
-	krakenConfig.AutomaticEnv()        // read in environment variables that match
+	krakenConfig.SetEnvPrefix("kraken") // prefix for env vars to configure client itself
+	krakenConfig.AutomaticEnv()         // read in environment variables that match
 
 	// Then configs
 	krakenConfig.SetConfigName("kraken.config") // name of config file (without extension)
@@ -228,17 +228,17 @@ func initK2CliConfig() {
 	}
 }
 
-func initKrakenClusterConfig(k2configPath string) error {
-	krakenClusterConfig.SetConfigFile(k2configPath)
+func initKrakenClusterConfig(krakenlibConfigPath string) error {
+	krakenClusterConfig.SetConfigFile(krakenlibConfigPath)
 	krakenClusterConfig.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	krakenClusterConfig.SetEnvPrefix("k2") // prefix for env vars to configure cluster
-	krakenClusterConfig.AutomaticEnv()     // read in environment variables that match
+	krakenClusterConfig.SetEnvPrefix("krakenlib") // prefix for env vars to configure cluster
+	krakenClusterConfig.AutomaticEnv()            // read in environment variables that match
 
 	// If a config file is found, read it in.
 	if err := krakenClusterConfig.ReadInConfig(); err != nil {
 		return err
 	}
 
-	fmt.Printf("Using K2 config file: %s \n", krakenClusterConfig.ConfigFileUsed())
+	fmt.Printf("Using Kraken config file: %s \n", krakenClusterConfig.ConfigFileUsed())
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,7 @@ var keepAlive bool
 var logPath string
 var logSuccess bool
 var verbosity bool
-var krakenTag string // this is set via linker flag
+var krakenlibTag string // this is set via linker flag
 
 // to be used by subcommands using --config
 var ClusterConfigPath string
@@ -79,8 +79,8 @@ func init() {
 
 	RootCmd.SetHelpCommand(helpCmd)
 
-	if krakenTag == "" {
-		krakenTag = "latest"
+	if krakenlibTag == "" {
+		krakenlibTag = "latest"
 	}
 
 	// Populate the global with a "vanilla" Docker configuration
@@ -104,8 +104,8 @@ func init() {
 		&containerImage,
 		"image",
 		"i",
-		"quay.io/samsung_cnct/k2:"+krakenTag,
-		"Kraken container image")
+		"quay.io/samsung_cnct/k2:"+krakenlibTag,
+		"Krakenlib container image")
 	RootCmd.PersistentFlags().StringVarP(
 		&outputLocation,
 		"output",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,7 @@ var keepAlive bool
 var logPath string
 var logSuccess bool
 var verbosity bool
-var krakenlibTag string // this is set via linker flag
+var KrakenlibTag string // this is set via linker flag
 
 // to be used by subcommands using --config
 var ClusterConfigPath string
@@ -79,8 +79,8 @@ func init() {
 
 	RootCmd.SetHelpCommand(helpCmd)
 
-	if krakenlibTag == "" {
-		krakenlibTag = "latest"
+	if KrakenlibTag == "" {
+		KrakenlibTag = "latest"
 	}
 
 	// Populate the global with a "vanilla" Docker configuration
@@ -104,7 +104,7 @@ func init() {
 		&containerImage,
 		"image",
 		"i",
-		"quay.io/samsung_cnct/k2:"+krakenlibTag,
+		"quay.io/samsung_cnct/k2:"+KrakenlibTag,
 		"Krakenlib container image")
 	RootCmd.PersistentFlags().StringVarP(
 		&outputLocation,

--- a/cmd/stages.go
+++ b/cmd/stages.go
@@ -23,7 +23,7 @@ import (
 // stagesCmd represents the stages command
 var stagesCmd = &cobra.Command{
 	Use:   "stages",
-	Short: "List of k2 stages",
+	Short: "List of Krakenlib stages",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(`
 Following stages are available:

--- a/cmd/stages.go
+++ b/cmd/stages.go
@@ -23,7 +23,7 @@ import (
 // stagesCmd represents the stages command
 var stagesCmd = &cobra.Command{
 	Use:   "stages",
-	Short: "List of Krakenlib stages",
+	Short: "List of Kraken stages",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(`
 Following stages are available:

--- a/cmd/tool.go
+++ b/cmd/tool.go
@@ -23,9 +23,9 @@ import (
 // toolCmd represents the tool command
 var toolCmd = &cobra.Command{
 	Use:   "tool",
-	Short: "Use tools with Krakenlib cluster",
+	Short: "Use tools with Kraken cluster",
 	Long: `Use various third-party tools with a
-	Krakenlib cluster configured by specified yaml`,
+	Kraken cluster configured by specified yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Usage()
 	},

--- a/cmd/tool.go
+++ b/cmd/tool.go
@@ -20,13 +20,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-
 // toolCmd represents the tool command
 var toolCmd = &cobra.Command{
 	Use:   "tool",
-	Short: "Use tools with K2 cluster",
-	Long: `Use various third-party tools with a 
-	K2 cluster configured by specified yaml`,
+	Short: "Use tools with Krakenlib cluster",
+	Long: `Use various third-party tools with a
+	Krakenlib cluster configured by specified yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Usage()
 	},
@@ -36,7 +35,7 @@ func init() {
 	RootCmd.AddCommand(toolCmd)
 
 	toolCmd.PersistentFlags().StringVarP(
-		&k2ConfigPath,
+		&krakenlibConfigPath,
 		"config",
 		"c",
 		os.ExpandEnv("$HOME/.kraken/config.yaml"),

--- a/cmd/tool.go
+++ b/cmd/tool.go
@@ -35,7 +35,7 @@ func init() {
 	RootCmd.AddCommand(toolCmd)
 
 	toolCmd.PersistentFlags().StringVarP(
-		&krakenlibConfigPath,
+		&ClusterConfigPath,
 		"config",
 		"c",
 		os.ExpandEnv("$HOME/.kraken/config.yaml"),

--- a/cmd/tool_helm.go
+++ b/cmd/tool_helm.go
@@ -28,11 +28,11 @@ import (
 // helmCmd represents the helm command
 var helmCmd = &cobra.Command{
 	Use:   "helm",
-	Short: "Use Kubernetes Helm with K2 cluster",
-	Long: `Use Kubernetes Helm with the  K2
+	Short: "Use Kubernetes Helm with a Krakenlib cluster",
+	Long: `Use Kubernetes Helm with the Krakenlib
 	cluster configured by the specified yaml file`,
 	PreRunE: preRunGetKrakenConfig,
-	RunE:     run,
+	RunE:    run,
 }
 
 func run(cmd *cobra.Command, args []string) error {
@@ -52,7 +52,7 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	if strings.Contains(verfiedHelmPath, minorMajorVersion) {
-		status, err := runHelm(helmPath, cli, backgroundCtx, args);
+		status, err := runHelm(helmPath, cli, backgroundCtx, args)
 		if err != nil {
 			return err
 		}
@@ -93,7 +93,8 @@ func verifyHelmPath(helmPath string, cli *client.Client) (string, error) {
 	command := []string{"test", "-f", helmPath}
 	ctx, cancel := getTimedContext()
 	defer cancel()
-	_, statusCode, timeout, err := containerAction(cli, ctx, command, k2ConfigPath)
+
+	_, statusCode, timeout, err := containerAction(cli, ctx, command, krakenlibConfigPath)
 	if err != nil {
 		return "", err
 	}
@@ -109,14 +110,14 @@ func verifyHelmPath(helmPath string, cli *client.Client) (string, error) {
 
 // Get the k8s version from k2
 func getK8sVersion(cli *client.Client, backgroundCtx context.Context, args []string) (string, error) {
-	command := []string{"/kraken/bin/max_k8s_version.sh", k2ConfigPath}
+	command := []string{"/kraken/bin/max_k8s_version.sh", krakenlibConfigPath}
 	for _, element := range args {
 		command = append(command, strings.Split(element, " ")...)
 	}
 
 	ctx, cancel := getTimedContext()
 	defer cancel()
-	resp, _, timeout, err := containerAction(cli, ctx, command, k2ConfigPath)
+	resp, _, timeout, err := containerAction(cli, ctx, command, krakenlibConfigPath)
 	if err != nil {
 		return "", err
 	}
@@ -141,7 +142,7 @@ func latestHelmVersion(cli *client.Client, backgroundCtx context.Context, args [
 
 	ctx, cancel := getTimedContext()
 	defer cancel()
-	resp, _, timeout, err := containerAction(cli, ctx, command, k2ConfigPath)
+	resp, _, timeout, err := containerAction(cli, ctx, command, krakenlibConfigPath)
 	if err != nil {
 		return "", err
 	}
@@ -171,7 +172,7 @@ func runHelm(helmPath string, cli *client.Client, backgroundCtx context.Context,
 
 	ctx, cancel := getTimedContext()
 	defer cancel()
-	resp, statusCode, timeout, err := containerAction(cli, ctx, command, k2ConfigPath)
+	resp, statusCode, timeout, err := containerAction(cli, ctx, command, krakenlibConfigPath)
 	if err != nil {
 		return -1, err
 	}

--- a/cmd/tool_helm.go
+++ b/cmd/tool_helm.go
@@ -108,7 +108,7 @@ func verifyHelmPath(helmPath string, cli *client.Client) (string, error) {
 	return helmPath, nil
 }
 
-// Get the k8s version from k2
+// Get the k8s version from Krakenlib
 func getK8sVersion(cli *client.Client, backgroundCtx context.Context, args []string) (string, error) {
 	command := []string{"/kraken/bin/max_k8s_version.sh", krakenlibConfigPath}
 	for _, element := range args {

--- a/cmd/tool_helm.go
+++ b/cmd/tool_helm.go
@@ -28,8 +28,8 @@ import (
 // helmCmd represents the helm command
 var helmCmd = &cobra.Command{
 	Use:   "helm",
-	Short: "Use Kubernetes Helm with a Krakenlib cluster",
-	Long: `Use Kubernetes Helm with the Krakenlib
+	Short: "Use Kubernetes Helm with a Kraken cluster",
+	Long: `Use Kubernetes Helm with the Kraken
 	cluster configured by the specified yaml file`,
 	PreRunE: preRunGetKrakenConfig,
 	RunE:    run,

--- a/cmd/tool_helm.go
+++ b/cmd/tool_helm.go
@@ -31,7 +31,7 @@ var helmCmd = &cobra.Command{
 	Short: "Use Kubernetes Helm with a Kraken cluster",
 	Long: `Use Kubernetes Helm with the Kraken
 	cluster configured by the specified yaml file`,
-	PreRunE: preRunGetKrakenConfig,
+	PreRunE: preRunGetClusterConfig,
 	RunE:    run,
 }
 
@@ -94,7 +94,7 @@ func verifyHelmPath(helmPath string, cli *client.Client) (string, error) {
 	ctx, cancel := getTimedContext()
 	defer cancel()
 
-	_, statusCode, timeout, err := containerAction(cli, ctx, command, krakenlibConfigPath)
+	_, statusCode, timeout, err := containerAction(cli, ctx, command, ClusterConfigPath)
 	if err != nil {
 		return "", err
 	}
@@ -110,14 +110,14 @@ func verifyHelmPath(helmPath string, cli *client.Client) (string, error) {
 
 // Get the k8s version from Krakenlib
 func getK8sVersion(cli *client.Client, backgroundCtx context.Context, args []string) (string, error) {
-	command := []string{"/kraken/bin/max_k8s_version.sh", krakenlibConfigPath}
+	command := []string{"/kraken/bin/max_k8s_version.sh", ClusterConfigPath}
 	for _, element := range args {
 		command = append(command, strings.Split(element, " ")...)
 	}
 
 	ctx, cancel := getTimedContext()
 	defer cancel()
-	resp, _, timeout, err := containerAction(cli, ctx, command, krakenlibConfigPath)
+	resp, _, timeout, err := containerAction(cli, ctx, command, ClusterConfigPath)
 	if err != nil {
 		return "", err
 	}
@@ -142,7 +142,7 @@ func latestHelmVersion(cli *client.Client, backgroundCtx context.Context, args [
 
 	ctx, cancel := getTimedContext()
 	defer cancel()
-	resp, _, timeout, err := containerAction(cli, ctx, command, krakenlibConfigPath)
+	resp, _, timeout, err := containerAction(cli, ctx, command, ClusterConfigPath)
 	if err != nil {
 		return "", err
 	}
@@ -172,7 +172,7 @@ func runHelm(helmPath string, cli *client.Client, backgroundCtx context.Context,
 
 	ctx, cancel := getTimedContext()
 	defer cancel()
-	resp, statusCode, timeout, err := containerAction(cli, ctx, command, krakenlibConfigPath)
+	resp, statusCode, timeout, err := containerAction(cli, ctx, command, ClusterConfigPath)
 	if err != nil {
 		return -1, err
 	}

--- a/cmd/tool_kubectl.go
+++ b/cmd/tool_kubectl.go
@@ -24,21 +24,21 @@ import (
 // kubectlCmd represents the kubectl command
 var kubectlCmd = &cobra.Command{
 	Use:   "kubectl",
-	Short: "Use Kubernetes kubectl with K2 cluster",
-	Long: `Use Kubernetes kubectl with the K2 
+	Short: "Use Kubernetes kubectl with Krakenlib cluster",
+	Long: `Use Kubernetes kubectl with the Krakenlib
 	cluster configured by the specified yaml file`,
 	PreRunE: preRunGetKrakenConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cli, _, err := pullKrakenContainerImage(containerImage)
 
-		command := []string{"/kraken/bin/computed_kubectl.sh", k2ConfigPath}
+		command := []string{"/kraken/bin/computed_kubectl.sh", krakenlibConfigPath}
 		for _, element := range args {
 			command = append(command, strings.Split(element, " ")...)
 		}
 
 		ctx, cancel := getTimedContext()
 		defer cancel()
-		resp, statusCode, timeout, err := containerAction(cli, ctx, command, k2ConfigPath)
+		resp, statusCode, timeout, err := containerAction(cli, ctx, command, krakenlibConfigPath)
 		if err != nil {
 			return err
 		}

--- a/cmd/tool_kubectl.go
+++ b/cmd/tool_kubectl.go
@@ -27,18 +27,18 @@ var kubectlCmd = &cobra.Command{
 	Short: "Use Kubernetes kubectl with Kraken cluster",
 	Long: `Use Kubernetes kubectl with the Kraken
 	cluster configured by the specified yaml file`,
-	PreRunE: preRunGetKrakenConfig,
+	PreRunE: preRunGetClusterConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cli, _, err := pullKrakenContainerImage(containerImage)
 
-		command := []string{"/kraken/bin/computed_kubectl.sh", krakenlibConfigPath}
+		command := []string{"/kraken/bin/computed_kubectl.sh", ClusterConfigPath}
 		for _, element := range args {
 			command = append(command, strings.Split(element, " ")...)
 		}
 
 		ctx, cancel := getTimedContext()
 		defer cancel()
-		resp, statusCode, timeout, err := containerAction(cli, ctx, command, krakenlibConfigPath)
+		resp, statusCode, timeout, err := containerAction(cli, ctx, command, ClusterConfigPath)
 		if err != nil {
 			return err
 		}

--- a/cmd/tool_kubectl.go
+++ b/cmd/tool_kubectl.go
@@ -24,8 +24,8 @@ import (
 // kubectlCmd represents the kubectl command
 var kubectlCmd = &cobra.Command{
 	Use:   "kubectl",
-	Short: "Use Kubernetes kubectl with Krakenlib cluster",
-	Long: `Use Kubernetes kubectl with the Krakenlib
+	Short: "Use Kubernetes kubectl with Kraken cluster",
+	Long: `Use Kubernetes kubectl with the Kraken
 	cluster configured by the specified yaml file`,
 	PreRunE: preRunGetKrakenConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/tool_ssh.go
+++ b/cmd/tool_ssh.go
@@ -22,7 +22,7 @@ import (
 var sshCmd = &cobra.Command{
 	Use:   "ssh",
 	Short: "ssh inventory management",
-	Long:  `manage Krakenlib ssh configuration file for cluster configured by the specified yaml`,
+	Long:  `manage Kraken ssh configuration file for cluster configured by the specified yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Usage()
 		ExitCode = 0

--- a/cmd/tool_ssh.go
+++ b/cmd/tool_ssh.go
@@ -22,7 +22,7 @@ import (
 var sshCmd = &cobra.Command{
 	Use:   "ssh",
 	Short: "ssh inventory management",
-	Long:  `manage K2 ssh configuration file for cluster configured by the specified yaml`,
+	Long:  `manage Krakenlib ssh configuration file for cluster configured by the specified yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Usage()
 		ExitCode = 0

--- a/cmd/tool_ssh_update.go
+++ b/cmd/tool_ssh_update.go
@@ -24,7 +24,7 @@ import (
 var sshUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Refresh ssh host list",
-	Long: `Update a list of SSH hosts for the Krakenlib 
+	Long: `Update a list of SSH hosts for the Kraken 
 	cluster configured by the specified yaml`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cli, backgroundCtx, err := pullKrakenContainerImage(containerImage)

--- a/cmd/tool_ssh_update.go
+++ b/cmd/tool_ssh_update.go
@@ -24,7 +24,7 @@ import (
 var sshUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Refresh ssh host list",
-	Long: `Update a list of SSH hosts for the K2 
+	Long: `Update a list of SSH hosts for the Krakenlib 
 	cluster configured by the specified yaml`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cli, backgroundCtx, err := pullKrakenContainerImage(containerImage)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,13 +16,14 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/blang/semver"
 	"github.com/spf13/cobra"
 )
 
-var K2CliMajorMinorPatch string
-var K2CliType = "alpha"
-var K2CliGitCommit string
+var KrakenMajorMinorPatch string
+var KrakenType = "alpha"
+var KrakenGitCommit string
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
@@ -30,7 +31,7 @@ var versionCmd = &cobra.Command{
 	Short: "Display cli version",
 	Long:  `Display cli version information`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		semVer, err := semver.Make(K2CliMajorMinorPatch + "-" + K2CliType + "+git.sha." + K2CliGitCommit);
+		semVer, err := semver.Make(KrakenMajorMinorPatch + "-" + KrakenType + "+git.sha." + KrakenGitCommit)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This covers issue: https://github.com/samsung-cnct/k2cli/issues/135

I changed all references to K2 and k2cli and followed the style that was already there. Used my best judgement on when to use Kraken vs Krakenlib for K2 based on the references in https://github.com/samsung-cnct/k2/pull/741, I would like feedback if there's a better approach on some of these changes.
