### PR TITLE
Changing flags: 'stages' found in up/down to 'tags',

### DIFF
--- a/cmd/cluster_down.go
+++ b/cmd/cluster_down.go
@@ -20,7 +20,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// deprecated
 var downStagesList string
+var downtagsList string
+
 
 // downCmd represents the down command
 var downCmd = &cobra.Command{
@@ -33,6 +36,14 @@ var downCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		spinnerPrefix := fmt.Sprintf("Bringing down cluster '%s' ", getFirstClusterName())
+		var tagList string
+
+		// remove when deprecation is finalized
+		if downStagesList == "all" {
+			tagList =  downtagsList
+		} else {
+			tagList = downStagesList
+		}
 
 		command := []string{
 			"ansible-playbook",
@@ -42,7 +53,7 @@ var downCmd = &cobra.Command{
 			"--extra-vars",
 			fmt.Sprintf("config_path=%s config_base=%s config_forced=%t kraken_action=down", ClusterConfigPath, outputLocation, configForced),
 			"--tags",
-			downStagesList,
+			tagList,
 		}
 
 		onFailure := func(out []byte) {
@@ -64,10 +75,20 @@ var downCmd = &cobra.Command{
 
 func init() {
 	clusterCmd.AddCommand(downCmd)
+
+	downCmd.PersistentFlags().StringVar(
+		&downtagsList,
+		"tags",
+		"all",
+		"comma-separated list of Kraken stages to run: [all, dryrun, config, fabric, master, node, assembler, readiness, services]",
+	)
+
 	downCmd.PersistentFlags().StringVarP(
 		&downStagesList,
 		"stages",
 		"s",
 		"all",
-		"comma-separated list of Kraken stages to run: [all, dryrun, config, fabric, master, node, assembler, readiness, services]")
+		"[DEPRECATED, please use --tags] comma-separated list of Kraken stages to run: [all, dryrun, config, fabric, master, node, assembler, readiness, services]",
+	)
+
 }

--- a/cmd/cluster_up.go
+++ b/cmd/cluster_up.go
@@ -20,7 +20,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// deprecated
 var upStagesList string
+var upTagsList string
 
 // upCmd represents the up command
 var upCmd = &cobra.Command{
@@ -31,6 +33,14 @@ var upCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		spinnerPrefix := fmt.Sprintf("Bringing up cluster '%s' ", getFirstClusterName())
+		var tagList string
+
+		// remove when deprecation is finalized
+		if upStagesList == "all" {
+			tagList =  upTagsList
+		} else {
+			tagList = upStagesList
+		}
 
 		command := []string{
 			"ansible-playbook",
@@ -40,7 +50,7 @@ var upCmd = &cobra.Command{
 			"--extra-vars",
 			fmt.Sprintf("config_path=%s config_base=%s config_forced=%t kraken_action=up", ClusterConfigPath, outputLocation, configForced),
 			"--tags",
-			upStagesList,
+			tagList,
 		}
 
 		onFailure := func(out []byte) {
@@ -64,10 +74,19 @@ var upCmd = &cobra.Command{
 
 func init() {
 	clusterCmd.AddCommand(upCmd)
+
+	upCmd.PersistentFlags().StringVar(
+		&upTagsList,
+		"tags",
+		"all",
+		"comma-separated list of Kraken stages to run. Run 'kraken help topic stages' for more info.",
+	)
+
 	upCmd.PersistentFlags().StringVarP(
 		&upStagesList,
 		"stages",
 		"s",
 		"all",
-		"comma-separated list of Kraken stages to run. Run 'kraken help topic stages' for more info.")
+		"[DEPRECATED, please use --tags] comma-separated list of Kraken stages to run. Run 'kraken help topic stages' for more info.",
+	)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes subcommand --tags for up/down commands consistent with shell use, stages as a name creates confusion.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

resolves https://github.com/samsung-cnct/k2cli/issues/130

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Changes include changing stages flags found in the cluster up/down commands to tags with shorthand t, and changing root command timeout to use capital T, to avoid conflict.
```
