### PR TITLE
put the '\' back so that we only build the desired targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ compile:
 	@$(GODEP) gox -ldflags "-X github.com/samsung-cnct/k2cli/cmd.KrakenMajorMinorPatch=$(VERSION) \
 									-X github.com/samsung-cnct/k2cli/cmd.KrakenType=$(TYPE) \
 									-X github.com/samsung-cnct/k2cli/cmd.KrakenGitCommit=$(COMMIT) \
-									-X github.com/samsung-cnct/k2cli/cmd.KrakenlibTag=$(KLIB_VER)"
+									-X github.com/samsung-cnct/k2cli/cmd.KrakenlibTag=$(KLIB_VER)" \
 	-osarch="linux/386" \
 	-osarch="linux/amd64" \
 	-osarch="darwin/amd64" \


### PR DESCRIPTION
we do not currently support kraken/k2cli across all of the platforms
that gox supports.  We need to only build for the platforms we support

<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:
limits build targets to our desired set
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
